### PR TITLE
Use Rodauth's new #check_csrf method for CSRF protection

### DIFF
--- a/lib/generators/rodauth/install_generator.rb
+++ b/lib/generators/rodauth/install_generator.rb
@@ -1,7 +1,6 @@
 require "rails/generators/base"
 require "rails/generators/migration"
 require "rails/generators/active_record"
-require "rodauth/version"
 
 module Rodauth
   module Rails

--- a/lib/generators/rodauth/mailer_generator.rb
+++ b/lib/generators/rodauth/mailer_generator.rb
@@ -1,5 +1,4 @@
 require "rails/generators/base"
-require "rodauth/version"
 
 module Rodauth
   module Rails

--- a/lib/generators/rodauth/views_generator.rb
+++ b/lib/generators/rodauth/views_generator.rb
@@ -1,5 +1,4 @@
 require "rails/generators/base"
-require "rodauth/version"
 
 module Rodauth
   module Rails

--- a/lib/rodauth/rails.rb
+++ b/lib/rodauth/rails.rb
@@ -1,3 +1,4 @@
+require "rodauth/version"
 require "rodauth/rails/railtie"
 
 module Rodauth

--- a/lib/rodauth/rails/feature.rb
+++ b/lib/rodauth/rails/feature.rb
@@ -28,6 +28,24 @@ module Rodauth
         super
     end
 
+    if Rodauth::MAJOR >= 2 && Rodauth::MINOR >= 1
+      # Verify Rails' authenticity token.
+      def check_csrf
+        rails_check_csrf!
+      end
+
+      # Have Rodauth call #check_csrf automatically.
+      def check_csrf?
+        true
+      end
+    else
+      # Verify Rails' authenticity token before each Rodauth route.
+      def before_rodauth
+        rails_check_csrf!
+        super
+      end
+    end
+
     # Render Rails CSRF tags in Rodauth templates.
     def csrf_tag(*)
       rails_csrf_tag
@@ -39,12 +57,6 @@ module Rodauth
     end
 
     private
-
-    # Verify Rails' authenticity token before each Rodauth route.
-    def before_rodauth
-      rails_check_csrf!
-      super
-    end
 
     # Create emails with ActionMailer which uses configured delivery method.
     def create_email_to(to, subject, body)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,6 @@
 ENV["RAILS_ENV"] = "test"
 
 require "bundler/setup"
-require "rodauth/version"
 require_relative "rails_app/config/environment"
 require "rails/test_help"
 require "capybara/rails"


### PR DESCRIPTION
This makes CSRF protection with Rails follow the same rules as when using Roda directly, meaning users can do things like override `#check_csrf?` to skip CSRF protection for certain routes, and that will now work correctly with rodauth-rails. The rodauth-oauth gem is one example where CSRF protection needs to be skipped for some routes.

We first need to wait for https://github.com/jeremyevans/rodauth/pull/96 to be merged, which adds the `#check_csrf` method.

Closes #2

/cc @HoneyryderChuck
