### PR TITLE
Test on JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - jruby-9.2.12.0
 
 gemfile:
   - gemfiles/Gemfile.rails-6.0
@@ -26,6 +27,12 @@ matrix:
     - rvm: 2.2
       gemfile: gemfiles/Gemfile.rails-5.2
     - rvm: 2.7
+      gemfile: gemfiles/Gemfile.rails-4.2
+    - rvm: jruby-9.2.12.0
+      gemfile: gemfiles/Gemfile.rails-5.1
+    - rvm: jruby-9.2.12.0
+      gemfile: gemfiles/Gemfile.rails-5.0
+    - rvm: jruby-9.2.12.0
       gemfile: gemfiles/Gemfile.rails-4.2
 
 before_script: "bundle update"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem "rake", "~> 12.0"
 
 gem "rails", ">= 4.2"
-gem "sqlite3", "~> 1.3"
+gem "sqlite3", "~> 1.3",                platforms: :mri
+gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 
 gem "capybara"

--- a/gemfiles/Gemfile.rails-5.2
+++ b/gemfiles/Gemfile.rails-5.2
@@ -5,7 +5,8 @@ gemspec path: ".."
 gem "rake", "~> 12.0"
 
 gem "rails", "~> 5.2.0"
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 1.4",                platforms: :mri
+gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 
 if RUBY_VERSION.start_with?("2.3.")
   gem "sprockets", "~> 3.7.2"

--- a/gemfiles/Gemfile.rails-6.0
+++ b/gemfiles/Gemfile.rails-6.0
@@ -5,6 +5,7 @@ gemspec path: ".."
 gem "rake", "~> 12.0"
 
 gem "rails", "~> 6.0.0"
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 1.4",                platforms: :mri
+gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 
 gem "capybara"

--- a/lib/generators/rodauth/install_generator.rb
+++ b/lib/generators/rodauth/install_generator.rb
@@ -56,13 +56,21 @@ module Rodauth
           end
         end
 
-        def sequel_adapter
-          return "jdbc" if RUBY_ENGINE == "jruby"
-
-          case activerecord_adapter
-          when "postgresql" then "postgres"
-          when "mysql2"     then "mysql2"
-          when "sqlite3"    then "sqlite"
+        if RUBY_ENGINE == "jruby"
+          def sequel_adapter
+            case activerecord_adapter
+            when "postgresql" then "postgresql"
+            when "mysql2"     then "mysql"
+            when "sqlite3"    then "sqlite"
+            end
+          end
+        else
+          def sequel_adapter
+            case activerecord_adapter
+            when "postgresql" then "postgres"
+            when "mysql2"     then "mysql2"
+            when "sqlite3"    then "sqlite"
+            end
           end
         end
 

--- a/lib/generators/rodauth/templates/config/initializers/sequel.rb
+++ b/lib/generators/rodauth/templates/config/initializers/sequel.rb
@@ -1,6 +1,10 @@
 require "sequel/core"
 
 # initialize the appropriate Sequel adapter without creating a connection
+<%- if RUBY_ENGINE == "jruby" -%>
+DB = Sequel.connect("jdbc:<%= sequel_adapter %>://", test: false)
+<% else -%>
 DB = Sequel.<%= sequel_adapter %>(test: false)
+<% end -%>
 # have Sequel use ActiveRecord's connection for database interaction
 DB.extension :activerecord_connection

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -32,7 +32,11 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator
     Sequel::DATABASES.push(db)
 
-    assert_file "config/initializers/sequel.rb", /Sequel\.sqlite\(test: false\)/
+    if RUBY_ENGINE == "jruby"
+      assert_file "config/initializers/sequel.rb", /Sequel\.connect\("jdbc:sqlite:\/\/", test: false\)/
+    else
+      assert_file "config/initializers/sequel.rb", /Sequel\.sqlite\(test: false\)/
+    end
   end
 
   test "app" do

--- a/test/rails_app/config/initializers/sequel.rb
+++ b/test/rails_app/config/initializers/sequel.rb
@@ -1,4 +1,4 @@
 require "sequel/core"
 
-DB = Sequel.sqlite(test: false)
+DB = Sequel.connect("#{"jdbc:" if RUBY_ENGINE == "jruby"}sqlite://", test: false)
 DB.extension :activerecord_connection


### PR DESCRIPTION
Now that sequel-activerecord_connection gem supports JRuby, we configure Travis CI to test rodauth-rails on JRuby as well.
