### PR TITLE
Fix default account status

### DIFF
--- a/lib/generators/rodauth/migration/base.erb
+++ b/lib/generators/rodauth/migration/base.erb
@@ -5,11 +5,11 @@ enable_extension "citext"
 create_table :accounts<%= primary_key_type %> do |t|
 <% case activerecord_adapter -%>
 <% when "postgresql" -%>
-  t.citext :email, null: false, index: { unique: true, where: "status IN ('verified', 'unverified')" }
+  t.citext :email, null: false, index: { unique: true, where: "status IN ('unverified', 'verified')" }
 <% else -%>
   t.string :email, null: false, index: { unique: true }
 <% end -%>
-  t.string :status, null: false, default: "verified"
+  t.string :status, null: false, default: "unverified"
 end
 
 # Used if storing password hashes in a separate table (default)

--- a/test/rails_app/db/migrate/20200411171322_create_rodauth.rb
+++ b/test/rails_app/db/migrate/20200411171322_create_rodauth.rb
@@ -11,7 +11,7 @@ class CreateRodauth < superclass
   def change
     create_table :accounts do |t|
       t.string :email, null: false, index: { unique: true }
-      t.string :status, null: false, default: "verified"
+      t.string :status, null: false, default: "unverified"
     end
 
     # Used if storing password hashes in a separate table (default)


### PR DESCRIPTION
Fixes Issue #27 

Change default account status to 'unverified' and reordered unique where status in constraint to match Rodauth default table setup: http://rodauth.jeremyevans.net/rdoc/files/README_rdoc.html#label-Creating+tables
