### PR TITLE
Fix rails api-only check

### DIFF
--- a/lib/rodauth/rails/app.rb
+++ b/lib/rodauth/rails/app.rb
@@ -12,7 +12,7 @@ module Rodauth
       plugin :hooks
       plugin :render, layout: false
 
-      unless ::Rails.configuration.api_only # not in API-only mode
+      unless ::Rails::VERSION::MAJOR > 4 && ::Rails.configuration.api_only # not in API-only mode
         require "rodauth/rails/app/flash"
         plugin Flash
       end

--- a/lib/rodauth/rails/app.rb
+++ b/lib/rodauth/rails/app.rb
@@ -12,7 +12,7 @@ module Rodauth
       plugin :hooks
       plugin :render, layout: false
 
-      if defined?(ActionDispatch::Flash) # not in API-only mode
+      unless ::Rails.configuration.api_only # not in API-only mode
         require "rodauth/rails/app/flash"
         plugin Flash
       end


### PR DESCRIPTION
Hey,

I noticed that for fresh Rails 6.1.2 app in api-only mode error from https://github.com/janko/rodauth-rails/issues/13 is still present.
```ruby
NoMethodError (undefined method `flash' for #<ActionDispatch::Request:0x00007fe26ad93600>):
```

This is because `ActionDispatch::Flash` is existing constant in the app, but it doesn't included in Request:
```ruby
$ rails c
Loading development environment (Rails 6.1.2)
[1] pry(main)> defined? ActionDispatch::Flash
=> "constant"
[2] pry(main)> ActionDispatch::Request.ancestors.include?(ActionDispatch::Flash::RequestMethods)
=> false
```

This PR changes rails api-only check so it'll rely on Rails configuration instead of defined constants.

Hope this help someone like me!