### PR TITLE
Add more params to multi configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,8 @@ class RodauthApp < Rodauth::Rails::App
     prefix "/admin"
     session_key_prefix "admin_"
     remember_cookie_key "_admin_remember" # if using remember feature
+    accounts_table :admin_accounts
+    password_hash_table :admin_account_password_hashes # if storing password hash in a different table
     # ...
   end
 


### PR DESCRIPTION
I'm integrating `rodauth-rails` in a new project, and I was confused about the way multiple accounts configuration is working.

Thanks to [rodauth's documentation][1] I was able to add the required parameters.

[1]: http://rodauth.jeremyevans.net/rdoc/files/doc/base_rdoc.html