### PR TITLE
Add controller-like request logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Add controller-like logging for requests to Rodauth endpoints (@janko)
+
 * Add `#rails_routes` to Roda and Rodauth instance for accessing Rails route helpers (@janko)
 
 * Add `#rails_request` to Roda and Rodauth instance for retrieving an `ActionDispatch::Request` instance (@janko)

--- a/lib/rodauth/rails/log_subscriber.rb
+++ b/lib/rodauth/rails/log_subscriber.rb
@@ -1,0 +1,34 @@
+module Rodauth
+  module Rails
+    class LogSubscriber < ActiveSupport::LogSubscriber
+      def start_processing(event)
+        rodauth = event.payload[:rodauth]
+        app_class = rodauth.scope.class.superclass
+        format = rodauth.rails_request.format.ref
+        format = format.to_s.upcase if format.is_a?(Symbol)
+        format = "*/*" if format.nil?
+
+        info "Processing by #{app_class} as #{format}"
+      end
+
+      def process_request(event)
+        status = event.payload[:status]
+
+        additions = ActionController::Base.log_process_action(event.payload)
+        if ::Rails.gem_version >= Gem::Version.new("6.0")
+          additions << "Allocations: #{event.allocations}"
+        end
+
+        message = "Completed #{status} #{Rack::Utils::HTTP_STATUS_CODES[status]} in #{event.duration.round}ms"
+        message << " (#{additions.join(" | ")})"
+        message << "\n\n" if defined?(::Rails.env) && ::Rails.env.development?
+
+        info message
+      end
+
+      def logger
+        ::Rails.logger
+      end
+    end
+  end
+end

--- a/lib/rodauth/rails/railtie.rb
+++ b/lib/rodauth/rails/railtie.rb
@@ -1,5 +1,6 @@
 require "rodauth/rails/middleware"
 require "rodauth/rails/controller_methods"
+require "rodauth/rails/log_subscriber"
 
 require "rails"
 
@@ -14,6 +15,10 @@ module Rodauth
         ActiveSupport.on_load(:action_controller) do
           include Rodauth::Rails::ControllerMethods
         end
+      end
+
+      initializer "rodauth.log_subscriber" do
+        Rodauth::Rails::LogSubscriber.attach_to :rodauth
       end
 
       initializer "rodauth.test" do

--- a/test/integration/json_test.rb
+++ b/test/integration/json_test.rb
@@ -3,14 +3,8 @@ require "test_helper"
 class JsonTest < IntegrationTest
   test "works with controller that inherits from ActionController::API" do
     page.driver.browser.post "/json/create-account",
-      JSON.generate({
-        "login"            => "user@example.com",
-        "password"         => "secret",
-        "password-confirm" => "secret",
-      }),
-      {
-        "CONTENT_TYPE" => "application/json",
-      }
+      { "login" => "user@example.com", "password" => "secret", "password-confirm" => "secret" }.to_json,
+      { "CONTENT_TYPE" => "application/json", "HTTP_ACCEPT" => "application/json" }
 
     assert_equal %({"success":"An email has been sent to you with a link to verify your account"}), page.html
 

--- a/test/integration/logging_test.rb
+++ b/test/integration/logging_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class LoggingTest < IntegrationTest
+  test "logs processing and completion of a request" do
+    logged = capture_log do
+      visit "/login"
+    end
+
+    assert_match /Started GET "\/login" for 127\.0\.0\.1/, logged
+    assert_match /Processing by RodauthApp as HTML/, logged
+    if ::Rails.gem_version >= Gem::Version.new("6.0")
+      assert_match /Completed 200 OK in \d+ms \(ActiveRecord: \d+\.\d+ms | Allocations: \d+\)/, logged
+    else
+      assert_match /Completed 200 OK in \d+ms \(ActiveRecord: \d+\.\d+ms\)/, logged
+    end
+  end
+
+  test "logs JSON requests" do
+    logged = capture_log do
+      page.driver.browser.post "/json/login",
+        { "login" => "user@example.com", "password" => "secret" }.to_json,
+        { "CONTENT_TYPE" => "application/json", "HTTP_ACCEPT" => "application/json" }
+    end
+
+    assert_match /Processing by RodauthApp as JSON/, logged
+    assert_match /Completed 401 Unauthorized/, logged
+  end
+
+  test "handles early response via callback" do
+    logged = capture_log do
+      visit "/login?early_return=true"
+    end
+
+    assert_match /Started GET "\/login\?early_return=true" for 127\.0\.0\.1/, logged
+    assert_match /Processing by RodauthApp as HTML/, logged
+    assert_match /Completed 201 Created in \d+ms/, logged
+  end
+
+  test "handles invalid HTTP verb" do
+    logged = capture_log do
+      page.driver.browser.head "/login"
+    end
+
+    assert_match /Completed 404 Not Found in \d+ms/, logged
+  end
+
+  private
+
+  def capture_log
+    io = StringIO.new
+    original_logger = Rails.logger
+    Rails.logger = Logger.new(io)
+    yield
+    Rails.logger = original_logger
+    io.string
+  end
+end


### PR DESCRIPTION
The `Rails::Rack::Logger` middleware already logs each request on the URL level, and view rendering is being logged as well. However, requests to controller actions also display:

```
Processing by MyController#some_action as HTML
# ...view render logging...
Completed 200 OK in 12ms (...more info...)
```

We want the same kind of nice logging for Rodauth requests, to communicate to the developer that the RodauthApp middleware has indeed caught the request, what was response status, and how long the whole request took.

We implement this using the same approach that Action Pack uses to implement controller-level logging. Now the developer sees this for a Rodauth request:

```
Started GET "/create-account" for 127.0.0.1 at 2021-05-06 17:46:12 +0200
Processing by RodauthApp as HTML
# ...view render logging...
Completed 200 OK in 15ms (ActiveRecord: 0.0ms | Allocations: 2443)
```
