### PR TITLE
Add Rodauth::Rails::Model for Active Record integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ Below is a list of all associations defined depending on the features loaded:
 | email_auth              | `:email_auth_key`            | `has_one`  | `EmailAuthKey`           | `account_email_auth_keys`           |
 | jwt_refresh             | `:jwt_refresh_keys`          | `has_many` | `JwtRefreshKey`          | `account_jwt_refresh_keys`          |
 | lockout                 | `:lockout`                   | `has_one`  | `Lockout`                | `account_lockouts`                  |
-| lockout                 | `:lockout`                   | `has_one`  | `LoginFailure`           | `account_login_failures`            |
+| lockout                 | `:login_failure`             | `has_one`  | `LoginFailure`           | `account_login_failures`            |
 | otp                     | `:otp_key`                   | `has_one`  | `OtpKey`                 | `account_otp_keys`                  |
 | password_expiration     | `:password_change_time`      | `has_one`  | `PasswordChangeTime`     | `account_password_change_times`     |
 | recovery_codes          | `:recovery_codes`            | `has_many` | `RecoveryCode`           | `account_recovery_codes`            |

--- a/README.md
+++ b/README.md
@@ -421,6 +421,165 @@ class CreateRodauthOtpSmsCodesRecoveryCodes < ActiveRecord::Migration
 end
 ```
 
+### Model
+
+The `Rodauth::Rails::Model` mixin can be included into the account model, which
+defines a password attribute with validations (similar to
+`has_secure_password`), login validations, and associations for tables used by
+enabled authentication features.
+
+```rb
+class Account < ApplicationRecord
+  include Rodauth::Rails.model # or `Rodauth::Rails.model(:admin)`
+end
+```
+
+#### Password attribute
+
+Regardless of whether you're storing the password hash in a column in the
+accounts table, or in a separate table, the `#password` attribute can be used
+to set or clear the password hash.
+
+```rb
+account = Account.new(email: "user@example.com", password: "secret")
+
+# when password hash is stored in a column on the accounts table
+account.password_hash #=> "$2a$12$k/Ub1I2iomi84RacqY89Hu4.M0vK7klRnRtzorDyvOkVI.hKhkNw."
+
+# when password hash is stored in a separate table
+account.password_hash #=> #<Account::PasswordHash...> (record from `account_password_hashes` table)
+account.password_hash.password_hash #=> "$2a$12$k/Ub1..." (inaccessible when using database authentication functions)
+
+account.password = nil # clears password hash
+account.password_hash #=> nil
+```
+
+Note that password will be validated only if it has changed or if in case of a
+new record.
+
+#### Validations
+
+By default, validations for password presence, password requirements (as
+defined in the Rodauth configuration), and password confirmation are defined:
+
+```rb
+account = Account.new(email: "user@example.com")
+account.valid? #=> false
+account.errors[:password] = ["can't be blank"]
+
+account.password = "foo"
+account.valid? #=> false
+account.errors[:password] = ["invalid password, does not meet requirements (minimum 6 characters)"]
+
+account.password = "secret"
+account.password_confirmation = "bla"
+account.valid? #=> false
+account.errors[:password] = ["passwords do not match"]
+```
+
+Similiarly, validations for login presence and login requirements are also
+defined:
+
+```rb
+account = Account.new(password: "secret")
+account.valid? #=> false
+account.errors[:email] #=> ["can't be blank"]
+
+account.email = "foo"
+account.valid? #=> false
+account.errors[:email] #=> ["invalid login, not a valid email address"]
+```
+
+You can disable any of these validations:
+
+```rb
+class Account < ApplicationRecord
+  # disables all validations
+  include Rodauth::Rails.model(validate: {
+    login_presence: false,
+    login_requirements: false,
+    password_presence: false,
+    password_requirements: false,
+    password_confirmation: false
+  })
+end
+```
+
+#### Associations
+
+The `Rodauth::Rails::Model` mixin defines associations for Rodauth tables
+associated to the accounts table:
+
+```rb
+account.remember_key #=> #<Account::RememberKey> (record from `account_remember_keys` table)
+account.active_session_keys #=> [#<Account::ActiveSessionKey>,...] (records from `account_active_session_keys` table)
+```
+
+You can use this for defining convenience methods on the account model:
+
+```rb
+class Account < ApplicationRecord
+  include Rodauth::Rails.model
+
+  # Returns whether account has multifactor authentication enabled (assuming otp
+  # sms_codes, and recovery_codes features are enabled).
+  def mfa_enabled?
+    otp_key || (sms_code && sms_code.num_failures.nil?) || recovery_codes.any?
+  end
+end
+```
+
+You can also reference the associated models directly:
+
+```rb
+# model referencing the `account_authentication_audit_logs` table
+Account::AuthenticationAuditLog.where(message: "login").group(:account_id)
+```
+
+The associated models define the inverse `belongs_to :account` association:
+
+```rb
+Account::ActiveSessionKey.includes(:account).map(&:account)
+```
+
+Below is a list of all associations defined depending on features loaded:
+
+| Feature                 | Association                  | Type       | Model                    | Table (default)                     |
+| :------                 | :----------                  | :---       | :----                    | :----                               |
+| account_expiration      | `:activity_time`             | `has_one`  | `ActivityTime`           | `account_activity_times`            |
+| active_sessions         | `:active_session_keys`       | `has_many` | `ActiveSessionKey`       | `account_active_session_keys`       |
+| audit_logging           | `:authentication_audit_logs` | `has_many` | `AuthenticationAuditLog` | `account_authentication_audit_logs` |
+| disallow_password_reuse | `:previous_password_hashes`  | `has_many` | `PreviousPasswordHash`   | `account_previous_password_hashes`  |
+| email_auth              | `:email_auth_key`            | `has_one`  | `EmailAuthKey`           | `account_email_auth_keys`           |
+| jwt_refresh             | `:jwt_refresh_keys`          | `has_many` | `JwtRefreshKey`          | `account_jwt_refresh_keys`          |
+| lockout                 | `:lockout`                   | `has_one`  | `Lockout`                | `account_lockouts`                  |
+| lockout                 | `:lockout`                   | `has_one`  | `LoginFailure`           | `account_login_failures`            |
+| otp                     | `:otp_key`                   | `has_one`  | `OtpKey`                 | `account_otp_keys`                  |
+| password_expiration     | `:password_change_time`      | `has_one`  | `PasswordChangeTime`     | `account_password_change_times`     |
+| recovery_codes          | `:recovery_codes`            | `has_many` | `RecoveryCode`           | `account_recovery_codes`            |
+| remember                | `:remember_key`              | `has_one`  | `RememberKey`            | `account_remember_keys`             |
+| reset_password          | `:password_reset_key`        | `has_one`  | `PasswordResetKey`       | `account_password_reset_keys`       |
+| single_session          | `:session_key`               | `has_one`  | `SessionKey`             | `account_session_keys`              |
+| sms_codes               | `:sms_code`                  | `has_one`  | `SmsCode`                | `account_sms_codes`                 |
+| verify_account          | `:verification_key`          | `has_one`  | `VerificationKey`        | `account_verification_keys`         |
+| verify_login_change     | `:login_change_key`          | `has_one`  | `LoginChangeKey`         | `account_login_change_keys`         |
+| webauthn                | `:webauthn_keys`             | `has_many` | `WebauthnKey`            | `account_webauthn_keys`             |
+| webauthn                | `:webauthn_user_id`          | `has_one`  | `WebauthnUserId`         | `account_webauthn_user_ids`         |
+
+By default, all associations except for audit logs have `dependent: :destroy`
+set, to allow for easy deletion of account records in the console. You can use
+`:association_options` to modify global or per-association options:
+
+```rb
+# don't auto-delete associations when account model is deleted
+Rodauth::Rails.model(association_options: { dependent: nil })
+
+# require authentication audit logs to be eager loaded before retrieval
+Rodauth::Rails.model(association_options: -> (name) {
+  { strict_loading: true } if name == :authentication_audit_logs
+})
+```
+
 ### Multiple configurations
 
 If you need to handle multiple types of accounts that require different
@@ -1073,29 +1232,6 @@ Rails.application.configure do |config|
   config.active_job.queue_adapter = :test # or :inline
   # ...
 end
-```
-
-If you need to create an account record with a password directly, you can do it
-as follows:
-
-```rb
-# app/models/account.rb
-class Account < ApplicationRecord
-  has_one :password_hash, foreign_key: :id
-end
-```
-```rb
-# app/models/account/password_hash.rb
-class Account::PasswordHash < ApplicationRecord
-  belongs_to :account, foreign_key: :id
-end
-```
-```rb
-require "bcrypt"
-
-account = Account.create!(email: "user@example.com", status: "verified")
-password_hash = BCrypt::Password.create("secret", cost: BCrypt::Engine::MIN_COST)
-account.create_password_hash!(id: account.id, password_hash: password_hash)
 ```
 
 ## Rodauth defaults

--- a/README.md
+++ b/README.md
@@ -480,8 +480,8 @@ The associated models define the inverse `belongs_to :account` association:
 Account::ActiveSessionKey.includes(:account).map(&:account)
 ```
 
-Here is an example of using the association methods to create a method that
-returns whether the account has multifactor authentication enabled:
+Here is an example of using associations to create a method that returns
+whether the account has multifactor authentication enabled:
 
 ```rb
 class Account < ApplicationRecord

--- a/README.md
+++ b/README.md
@@ -453,6 +453,10 @@ account.password = nil # clears password hash
 account.password_hash #=> nil
 ```
 
+Note that the password attribute doesn't come with validations, making it
+unsuitable for forms. It was primarily intended to allow easily creating
+accounts in development console and in tests.
+
 #### Associations
 
 The `Rodauth::Rails::Model` mixin defines associations for Rodauth tables

--- a/gemfiles/Gemfile.rails-5.0
+++ b/gemfiles/Gemfile.rails-5.0
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec path: ".."
 
 gem "rake", "~> 12.0"
+gem "minitest", "5.10.3"
 
 gem "rails", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6",              platforms: :mri

--- a/lib/generators/rodauth/templates/app/models/account.rb
+++ b/lib/generators/rodauth/templates/app/models/account.rb
@@ -1,2 +1,3 @@
 class Account < ApplicationRecord
+  include Rodauth::Rails.model
 end

--- a/lib/rodauth/rails.rb
+++ b/lib/rodauth/rails.rb
@@ -12,6 +12,7 @@ module Rodauth
     # This allows the developer to avoid loading Rodauth at boot time.
     autoload :App, "rodauth/rails/app"
     autoload :Auth, "rodauth/rails/auth"
+    autoload :Model, "rodauth/rails/model"
 
     @app = nil
     @middleware = true
@@ -49,6 +50,11 @@ module Rodauth
         end
 
         instance
+      end
+
+      def model(name = nil, **options)
+        rodauth_class = Rodauth::Rails.app.rodauth(name)
+        Rodauth::Rails::Model.new(rodauth_class, **options)
       end
 
       # routing constraint that requires authentication

--- a/lib/rodauth/rails.rb
+++ b/lib/rodauth/rails.rb
@@ -53,8 +53,7 @@ module Rodauth
       end
 
       def model(name = nil, **options)
-        rodauth_class = Rodauth::Rails.app.rodauth(name)
-        Rodauth::Rails::Model.new(rodauth_class, **options)
+        Rodauth::Rails::Model.new(app.rodauth(name), **options)
       end
 
       # routing constraint that requires authentication

--- a/lib/rodauth/rails/model.rb
+++ b/lib/rodauth/rails/model.rb
@@ -1,0 +1,162 @@
+module Rodauth
+  module Rails
+    class Model < Module
+      require "rodauth/rails/model/associations"
+
+      VALIDATE_DEFAULTS = {
+        login_presence: true,
+        login_requirements: true,
+        password_presence: true,
+        password_requirements: true,
+        password_confirmation: true,
+      }
+
+      def initialize(rodauth_class, validate: {}, association_options: {})
+        validate.each_key { |key| VALIDATE_DEFAULTS.fetch(key) } # fail for invalid validate keys
+
+        @rodauth_class = rodauth_class
+        @validate = validate ? VALIDATE_DEFAULTS.merge(validate) : {}
+        @association_options = association_options
+
+        define_methods
+      end
+
+      def included(model)
+        fail Rodauth::Rails::Error, "must be an Active Record model" unless model < ActiveRecord::Base
+
+        define_associations(model)
+        define_validations(model)
+      end
+
+      private
+
+      def define_methods
+        rodauth_class = @rodauth_class
+
+        module_eval do
+          attr_reader :password
+          attr_accessor :password_confirmation if validate?(:password_confirmation)
+
+          def password=(password)
+            @password = password
+            password_hash = rodauth.send(:password_hash, password) if password
+            set_password_hash(password_hash)
+          end
+
+          def set_password_hash(password_hash)
+            if rodauth.account_password_hash_column
+              public_send(:"#{rodauth.account_password_hash_column}=", password_hash)
+            else
+              if password_hash
+                record = self.password_hash || build_password_hash
+                record.public_send(:"#{rodauth.password_hash_column}=", password_hash)
+              else
+                self.password_hash&.mark_for_destruction
+              end
+            end
+          end
+
+          private
+
+          def validate_password_requirements
+            unless rodauth.password_meets_requirements?(password.to_s) || password.to_s.empty?
+              errors.add(:password, rodauth.send(:password_does_not_meet_requirements_message))
+            end
+          end if validate?(:password_requirements)
+
+          def validate_password_confirmation
+            if password_confirmation && password != password_confirmation
+              errors.add(:password, rodauth.passwords_do_not_match_message)
+            end
+          end if validate?(:password_confirmation)
+
+          def validate_login_requirements
+            login = public_send(rodauth.login_column)
+            unless rodauth.login_meets_requirements?(login.to_s) || login.to_s.empty?
+              errors.add(rodauth.login_column, rodauth.send(:login_does_not_meet_requirements_message))
+            end
+          end if validate?(:login_requirements)
+
+          def password_changed?
+            instance_variable_defined?(:@password) || new_record?
+          end
+
+          define_method :rodauth do
+            @rodauth ||= (
+              rodauth = rodauth_class.allocate
+              rodauth.instance_variable_set(:@account, attributes.symbolize_keys)
+              rodauth
+            )
+          end
+        end
+      end
+
+      def define_associations(model)
+        define_password_hash_association(model) unless rodauth.account_password_hash_column
+
+        feature_associations.each do |association|
+          define_association(model, **association)
+        end
+      end
+
+      def define_password_hash_association(model)
+        password_hash_id_column = rodauth.password_hash_id_column
+        scope = -> { select(password_hash_id_column) } if rodauth.send(:use_database_authentication_functions?)
+
+        define_association model,
+          type: :has_one,
+          name: :password_hash,
+          table: rodauth.password_hash_table,
+          foreign_key: password_hash_id_column,
+          scope: scope,
+          autosave: true
+      end
+
+      def define_association(model, type:, name:, table:, foreign_key:, scope: nil, **options)
+        associated_model = Class.new(model.superclass)
+        associated_model.table_name = table
+        associated_model.belongs_to :account,
+          class_name: model.name,
+          foreign_key: foreign_key,
+          inverse_of: name
+
+        model.const_set(name.to_s.singularize.camelize, associated_model)
+
+        model.public_send type, name, scope,
+          class_name: associated_model.name,
+          foreign_key: foreign_key,
+          dependent: :destroy,
+          inverse_of: :account,
+          **options,
+          **association_options(name)
+      end
+
+      def define_validations(model)
+        model.validates_presence_of rodauth.login_column if validate?(:login_presence)
+        model.validate :validate_login_requirements if validate?(:login_requirements)
+
+        model.validates_presence_of :password, if: :password_changed? if validate?(:password_presence)
+        model.validate :validate_password_requirements, if: :password_changed? if validate?(:password_requirements)
+        model.validate :validate_password_confirmation, if: :password_changed? if validate?(:password_confirmation)
+      end
+
+      def feature_associations
+        Rodauth::Rails::Model::Associations.call(rodauth)
+      end
+
+      def validate?(name)
+        @validate.fetch(name)
+      end
+
+      def association_options(name)
+        options = @association_options
+        options = options.call(name) if options.respond_to?(:call)
+        options || {}
+      end
+
+      def rodauth
+        @rodauth_class.allocate
+      end
+    end
+  end
+end

--- a/lib/rodauth/rails/model/associations.rb
+++ b/lib/rodauth/rails/model/associations.rb
@@ -1,0 +1,195 @@
+module Rodauth
+  module Rails
+    class Model
+      class Associations
+        attr_reader :rodauth
+
+        def self.call(rodauth)
+          new(rodauth).call
+        end
+
+        def initialize(rodauth)
+          @rodauth = rodauth
+        end
+
+        def call
+          rodauth.features
+            .select { |feature| respond_to?(feature, true) }
+            .flat_map { |feature| send(feature) }
+        end
+
+        private
+
+        def remember
+          {
+            name: :remember_key,
+            type: :has_one,
+            table: rodauth.remember_table,
+            foreign_key: rodauth.remember_id_column,
+          }
+        end
+
+        def verify_account
+          {
+            name: :verification_key,
+            type: :has_one,
+            table: rodauth.verify_account_table,
+            foreign_key: rodauth.verify_account_id_column,
+          }
+        end
+
+        def reset_password
+          {
+            name: :password_reset_key,
+            type: :has_one,
+            table: rodauth.reset_password_table,
+            foreign_key: rodauth.reset_password_id_column,
+          }
+        end
+
+        def verify_login_change
+          {
+            name: :login_change_key,
+            type: :has_one,
+            table: rodauth.verify_login_change_table,
+            foreign_key: rodauth.verify_login_change_id_column,
+          }
+        end
+
+        def lockout
+          [
+            {
+              name: :lockout,
+              type: :has_one,
+              table: rodauth.account_lockouts_table,
+              foreign_key: rodauth.account_lockouts_id_column,
+            },
+            {
+              name: :login_failure,
+              type: :has_one,
+              table: rodauth.account_login_failures_table,
+              foreign_key: rodauth.account_login_failures_id_column,
+            }
+          ]
+        end
+
+        def email_auth
+          {
+            name: :email_auth_key,
+            type: :has_one,
+            table: rodauth.email_auth_table,
+            foreign_key: rodauth.email_auth_id_column,
+          }
+        end
+
+        def account_expiration
+          {
+            name: :activity_time,
+            type: :has_one,
+            table: rodauth.account_activity_table,
+            foreign_key: rodauth.account_activity_id_column,
+          }
+        end
+
+        def active_sessions
+          {
+            name: :active_session_keys,
+            type: :has_many,
+            table: rodauth.active_sessions_table,
+            foreign_key: rodauth.active_sessions_account_id_column,
+          }
+        end
+
+        def audit_logging
+          {
+            name: :authentication_audit_logs,
+            type: :has_many,
+            table: rodauth.audit_logging_table,
+            foreign_key: rodauth.audit_logging_account_id_column,
+            dependent: nil,
+          }
+        end
+
+        def disallow_password_reuse
+          {
+            name: :previous_password_hashes,
+            type: :has_many,
+            table: rodauth.previous_password_hash_table,
+            foreign_key: rodauth.previous_password_account_id_column,
+          }
+        end
+
+        def jwt_refresh
+          {
+            name: :jwt_refresh_keys,
+            type: :has_many,
+            table: rodauth.jwt_refresh_token_table,
+            foreign_key: rodauth.jwt_refresh_token_account_id_column,
+          }
+        end
+
+        def password_expiration
+          {
+            name: :password_change_time,
+            type: :has_one,
+            table: rodauth.password_expiration_table,
+            foreign_key: rodauth.password_expiration_id_column,
+          }
+        end
+
+        def single_session
+          {
+            name: :session_key,
+            type: :has_one,
+            table: rodauth.single_session_table,
+            foreign_key: rodauth.single_session_id_column,
+          }
+        end
+
+        def otp
+          {
+            name: :otp_key,
+            type: :has_one,
+            table: rodauth.otp_keys_table,
+            foreign_key: rodauth.otp_keys_id_column,
+          }
+        end
+
+        def sms_codes
+          {
+            name: :sms_code,
+            type: :has_one,
+            table: rodauth.sms_codes_table,
+            foreign_key: rodauth.sms_id_column,
+          }
+        end
+
+        def recovery_codes
+          {
+            name: :recovery_codes,
+            type: :has_many,
+            table: rodauth.recovery_codes_table,
+            foreign_key: rodauth.recovery_codes_id_column,
+          }
+        end
+
+        def webauthn
+          [
+            {
+              name: :webauthn_user_id,
+              type: :has_one,
+              table: rodauth.webauthn_user_ids_table,
+              foreign_key: rodauth.webauthn_user_ids_account_id_column,
+            },
+            {
+              name: :webauthn_keys,
+              type: :has_many,
+              table: rodauth.webauthn_keys_table,
+              foreign_key: rodauth.webauthn_keys_account_id_column,
+            }
+          ]
+        end
+      end
+    end
+  end
+end

--- a/rodauth-rails.gemspec
+++ b/rodauth-rails.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "jwt"
   spec.add_development_dependency "rotp"
   spec.add_development_dependency "rqrcode"
-  spec.add_development_dependency "webauthn"
+  spec.add_development_dependency "webauthn" unless RUBY_ENGINE == "jruby"
 end

--- a/rodauth-rails.gemspec
+++ b/rodauth-rails.gemspec
@@ -23,4 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bcrypt"
 
   spec.add_development_dependency "jwt"
+  spec.add_development_dependency "rotp"
+  spec.add_development_dependency "rqrcode"
+  spec.add_development_dependency "webauthn"
 end

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -121,14 +121,18 @@ class ModelTest < UnitTest
     account.create_sms_code!(id: account.id, phone_number: "0123456789")
     assert_instance_of account.class::SmsCode, account.sms_code
 
-    capture_io { account.recovery_codes.create!(id: account.id, code: "foo") }
-    assert_instance_of account.class::RecoveryCode, account.recovery_codes.first
+    if Rails.gem_version >= Gem::Version.new("5.0")
+      capture_io { account.recovery_codes.create!(id: account.id, code: "foo") }
+      assert_instance_of account.class::RecoveryCode, account.recovery_codes.first
+    end
 
     account.create_webauthn_user_id!(id: account.id, webauthn_id: "id")
     assert_instance_of account.class::WebauthnUserId, account.webauthn_user_id
 
-    capture_io { account.webauthn_keys.create!(webauthn_id: "id", public_key: "key", sign_count: 1) }
-    assert_instance_of account.class::WebauthnKey, account.webauthn_keys.first
+    if Rails.gem_version >= Gem::Version.new("5.0")
+      capture_io { account.webauthn_keys.create!(webauthn_id: "id", public_key: "key", sign_count: 1) }
+      assert_instance_of account.class::WebauthnKey, account.webauthn_keys.first
+    end
   end
 
   test "automatically destroying associations" do

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -144,27 +144,21 @@ class ModelTest < UnitTest
   end
 
   test "passing association options hash" do
-    account = build_account(association_options: { dependent: nil })
-    account.save!
-    account.create_remember_key!(id: account.id, key: "key", deadline: Time.now)
-
-    assert_raises(ActiveRecord::InvalidForeignKey) { account.destroy }
+    account = build_account(association_options: { dependent: :nullify })
+    association = account.class.reflect_on_association(:remember_key)
+    assert_equal :nullify, association.options[:dependent]
   end
 
   test "passing association options block" do
     account = build_account(association_options: -> (name) {
-      { dependent: nil } if name == :remember_key
+      { dependent: :nullify } if name == :remember_key
     })
 
-    account.save!
-    account.create_remember_key!(id: account.id, key: "key", deadline: Time.now)
+    remember_association = account.class.reflect_on_association(:remember_key)
+    assert_equal :nullify, remember_association.options[:dependent]
 
-    assert_raises(ActiveRecord::InvalidForeignKey) { account.destroy }
-
-    account.remember_key.destroy
-    account.create_verification_key(id: account.id, key: "key")
-
-    account.destroy
+    verification_association = account.class.reflect_on_association(:verification_key)
+    assert_equal :destroy, verification_association.options[:dependent]
   end
 
   test "inverse association" do

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1,0 +1,345 @@
+require "test_helper"
+
+class ModelTest < UnitTest
+  test "password attribute with a column" do
+    account = password_column_account
+
+    account.password = "secret"
+    assert_equal "secret", account.password
+
+    refute_nil account.password_hash
+    assert_operator BCrypt::Password.new(account.password_hash), :==, "secret"
+
+    account.password = "new secret"
+    assert_operator BCrypt::Password.new(account.password_hash), :==, "new secret"
+
+    account.password = ""
+    refute_nil account.password_hash
+
+    account.password = nil
+    assert_nil account.password_hash
+  end
+
+  test "password attribute with a table" do
+    account = password_table_account
+
+    account.password = "secret"
+    assert_equal "secret", account.password
+
+    assert_instance_of account.class::PasswordHash, account.password_hash
+    assert_operator BCrypt::Password.new(account.password_hash.password_hash), :==, "secret"
+
+    refute account.password_hash.persisted?
+    account.save!
+    assert account.password_hash.persisted?
+
+    account.password = "new secret"
+    assert_operator BCrypt::Password.new(account.password_hash.password_hash), :==, "new secret"
+    account.password_hash.password_hash_changed?
+
+    account.save!
+    refute account.password_hash.changed?
+    assert_operator BCrypt::Password.new(account.password_hash.password_hash), :==, "new secret"
+
+    account.password = ""
+    assert_operator BCrypt::Password.new(account.password_hash.password_hash), :==, ""
+
+    account.password = nil
+    refute account.password_hash.destroyed?
+    account.save!
+    assert account.password_hash.destroyed?
+
+    account.reload
+    assert_nil account.password_hash
+  end
+
+  test "not selecting password hash column when using database authentication functions" do
+    account = build_account { use_database_authentication_functions? true }
+    account.update(password: "secret")
+    account.reload
+
+    assert_equal account.id, account.password_hash.id
+    assert_raises ActiveModel::MissingAttributeError do
+      account.password_hash.password_hash
+    end
+  end
+
+  test "password requirements validation" do
+    account = password_column_account
+
+    account.password = "foo"
+    refute account.valid?
+    assert_equal ["invalid password, does not meet requirements (minimum 6 characters)"], account.errors[:password]
+
+    account.password = "foobar"
+    assert account.valid?
+  end
+
+  test "per-account password requirements validation" do
+    account = build_account do
+      account_password_hash_column :password_hash
+      password_minimum_length { @account[:email].length }
+    end
+
+    account.password = "foobar"
+    refute account.valid?
+
+    account.password = "long enough password"
+    assert account.valid?
+  end
+
+  test "disabling password requirements validation" do
+    account = password_column_account(validate: { password_requirements: false })
+    account.password = "a"
+    assert account.valid?
+  end
+
+  test "password presence validation with password column" do
+    account = password_column_account(validate: { password_presence: true })
+
+    refute account.valid?
+    assert_equal ["can't be blank"], account.errors[:password]
+
+    account.password = ""
+    refute account.valid?
+    assert_equal ["can't be blank"], account.errors[:password]
+
+    account.password = "secret"
+    assert account.valid?
+  end
+
+  test "password presence validation with password table" do
+    account = password_table_account(validate: { password_presence: true })
+
+    refute account.valid?
+    assert_equal ["can't be blank"], account.errors[:password]
+
+    account.password = ""
+    refute account.valid?
+    assert_equal ["can't be blank"], account.errors[:password]
+
+    account.password = "secret"
+    assert account.valid?
+
+    account.save!
+    account.password = nil
+    refute account.valid?
+    assert_equal ["can't be blank"], account.errors[:password]
+  end
+
+  test "disabling password presence validation" do
+    account = password_column_account(validate: { password_presence: false })
+    assert account.valid?
+  end
+
+  test "password confirmation validation" do
+    account = password_column_account
+    account.password = "secret"
+    account.password_confirmation = ""
+    refute account.valid?
+    assert_equal ["passwords do not match"], account.errors[:password]
+    account.password_confirmation = "foobar"
+    refute account.valid?
+    assert_equal ["passwords do not match"], account.errors[:password]
+    account.password_confirmation = "secret"
+    assert account.valid?
+  end
+
+  test "disabling password confirmation validation" do
+    account = password_column_account(validate: { password_confirmation: false })
+    refute account.respond_to?(:password_confirmation)
+  end
+
+  test "login presence validation" do
+    account = build_account
+
+    account.email = nil
+    refute account.valid?
+    assert_equal ["can't be blank"], account.errors[:email]
+
+    account.email = ""
+    refute account.valid?
+    assert_equal ["can't be blank"], account.errors[:email]
+
+    account.email = "user@example.com"
+    assert account.valid?
+  end
+
+  test "login requirements validation" do
+    account = build_account
+
+    account.email = "f"
+    refute account.valid?
+    assert_equal ["invalid login, minimum 3 characters"], account.errors[:email]
+
+    account.email = "foo"
+    refute account.valid?
+    assert_equal ["invalid login, not a valid email address"], account.errors[:email]
+
+    account.email = "foo@bar.com"
+    assert account.valid?
+  end
+
+  test "feature associations" do
+    account = build_account do
+      enable :jwt_refresh, :email_auth, :account_expiration, :audit_logging,
+        :disallow_password_reuse, :otp, :sms_codes, :webauthn,
+        :password_expiration, :single_session
+    end
+
+    account.save!
+
+    account.create_remember_key!(id: account.id, key: "key", deadline: Time.now)
+    assert_instance_of account.class::RememberKey, account.remember_key
+
+    account.create_verification_key(id: account.id, key: "key")
+    assert_instance_of account.class::VerificationKey, account.verification_key
+
+    account.create_password_reset_key(id: account.id, key: "key", deadline: Time.now)
+    assert_instance_of account.class::PasswordResetKey, account.password_reset_key
+
+    account.create_login_change_key(id: account.id, key: "key", login: "foo@bar.com", deadline: Time.now)
+    assert_instance_of account.class::LoginChangeKey, account.login_change_key
+
+    account.create_lockout!(id: account.id, key: "key", deadline: Time.now)
+    assert_instance_of account.class::Lockout, account.lockout
+
+    account.create_login_failure!(id: account.id)
+    assert_instance_of account.class::LoginFailure, account.login_failure
+
+    account.create_email_auth_key!(id: account.id, key: "key", deadline: Time.now)
+    assert_instance_of account.class::EmailAuthKey, account.email_auth_key
+
+    account.create_activity_time!(id: account.id, last_activity_at: Time.now, last_login_at: Time.now)
+    assert_instance_of account.class::ActivityTime, account.activity_time
+
+    capture_io { account.active_session_keys.create!(session_id: "1") }
+    assert_instance_of account.class::ActiveSessionKey, account.active_session_keys.first
+
+    account.authentication_audit_logs.create!(message: "Foo")
+    assert_instance_of account.class::AuthenticationAuditLog, account.authentication_audit_logs.first
+
+    account.previous_password_hashes.create!(password_hash: "secret")
+    assert_instance_of account.class::PreviousPasswordHash, account.previous_password_hashes.first
+
+    account.jwt_refresh_keys.create!(key: "foo", deadline: Time.now)
+    assert_instance_of account.class::JwtRefreshKey, account.jwt_refresh_keys.first
+
+    account.create_password_change_time!(id: account.id)
+    assert_instance_of account.class::PasswordChangeTime, account.password_change_time
+
+    account.create_session_key!(id: account.id, key: "key")
+    assert_instance_of account.class::SessionKey, account.session_key
+
+    account.create_otp_key!(id: account.id, key: "key")
+    assert_instance_of account.class::OtpKey, account.otp_key
+
+    account.create_sms_code!(id: account.id, phone_number: "0123456789")
+    assert_instance_of account.class::SmsCode, account.sms_code
+
+    capture_io { account.recovery_codes.create!(id: account.id, code: "foo") }
+    assert_instance_of account.class::RecoveryCode, account.recovery_codes.first
+
+    account.create_webauthn_user_id!(id: account.id, webauthn_id: "id")
+    assert_instance_of account.class::WebauthnUserId, account.webauthn_user_id
+
+    capture_io { account.webauthn_keys.create!(webauthn_id: "id", public_key: "key", sign_count: 1) }
+    assert_instance_of account.class::WebauthnKey, account.webauthn_keys.first
+  end
+
+  test "automatically destroying associations" do
+    account = build_account { enable :audit_logging }
+    account.update!(password: "secret")
+    account.create_remember_key!(id: account.id, key: "key", deadline: Time.now)
+    account.authentication_audit_logs.create!(message: "Foo")
+    account.destroy
+
+    assert account.password_hash.destroyed?
+    assert account.remember_key.destroyed?
+    assert_equal 1, account.class::AuthenticationAuditLog.count
+  end
+
+  test "passing association options hash" do
+    account = build_account(association_options: { dependent: nil })
+    account.save!
+    account.create_remember_key!(id: account.id, key: "key", deadline: Time.now)
+
+    assert_raises(ActiveRecord::InvalidForeignKey) { account.destroy }
+  end
+
+  test "passing association options block" do
+    account = build_account(association_options: -> (name) {
+      { dependent: nil } if name == :remember_key
+    })
+
+    account.save!
+    account.create_remember_key!(id: account.id, key: "key", deadline: Time.now)
+
+    assert_raises(ActiveRecord::InvalidForeignKey) { account.destroy }
+
+    account.remember_key.destroy
+    account.create_verification_key(id: account.id, key: "key")
+
+    account.destroy
+  end
+
+  test "inverse association" do
+    account = build_account
+    account.save!
+    account.create_remember_key!(id: account.id, key: "key", deadline: Time.now)
+    account.reload
+
+    assert_equal account.object_id, account.remember_key.account.object_id
+  end
+
+  test "module builder method with default configuration" do
+    account_class = define_account_class
+    account_class.include Rodauth::Rails.model(validate: { password_presence: false })
+    assert account_class.reflect_on_association(:password_reset_key)
+    account = account_class.new(email: "user@example.com")
+    assert account.valid?
+  end
+
+  test "module builder method with secondary configuration" do
+    account_class = define_account_class
+    account_class.include Rodauth::Rails.model(:json, validate: { password_requirements: false })
+    assert account_class.reflect_on_association(:verification_key)
+    refute account_class.reflect_on_association(:password_reset_key)
+    account = account_class.new(email: "user@example.com", password: "a")
+    assert account.valid?
+  end
+
+  private
+
+  def password_column_account(**options)
+    build_account(**options) { account_password_hash_column :password_hash }
+  end
+
+  def password_table_account(**options)
+    ActiveRecord::Base.connection.remove_column :accounts, :password_hash
+    build_account(**options) { account_password_hash_column nil }
+  end
+
+  def build_account(**options, &block)
+    account_class = define_account_class
+
+    rodauth_class = Class.new(Rodauth::Rails.app.rodauth)
+    rodauth_class.configure { instance_exec(&block) if block }
+
+    account_class.include Rodauth::Rails::Model.new(rodauth_class, validate: { password_presence: false }, **options)
+    account_class.new(email: "user@example.com")
+  end
+
+  def define_account_class
+    account_class = Class.new(ActiveRecord::Base)
+    account_class.table_name = :accounts
+    self.class.const_set(:Account, account_class) # give it a name
+    account_class
+  end
+
+  def teardown
+    self.class.send(:remove_const, :Account) if self.class.constants.include?(:Account)
+    ActiveSupport::Dependencies.clear # clear cache used for :class_name association option
+    super
+  end
+end

--- a/test/rails_app/app/models/account.rb
+++ b/test/rails_app/app/models/account.rb
@@ -1,2 +1,3 @@
 class Account < ApplicationRecord
+  validates_presence_of :email
 end

--- a/test/rails_app/db/migrate/20200411171322_create_rodauth.rb
+++ b/test/rails_app/db/migrate/20200411171322_create_rodauth.rb
@@ -12,6 +12,7 @@ class CreateRodauth < superclass
     create_table :accounts do |t|
       t.string :email, null: false, index: { unique: true }
       t.string :status, null: false, default: "unverified"
+      t.string :password_hash
     end
 
     # Used if storing password hashes in a separate table (default)


### PR DESCRIPTION
Currently, creating an account with a password programmatically is a bit cumbersome, mostly due to bcrypt-hashing, especially when the password is stored in a separate table. This adds friction in development and in tests, and also for anyone wanting to implement simple user creation by admins. Devise, Sorcery, and has_secure_password all provide this level
of convenience.

Additionally, there are cases where it's useful to be able to directly query associated tables (e.g. retrieving all accounts that have MFA enabled), and it might not be obvious how to declare associations, e.g:

```rb
class Account < ApplicationRecord
  has_one :remember_key, foreign_key: :id
end

class Account::RememberKey < ApplicationRecord
end
```

To address this friction, we add a `Rodauth::Rails::Model` mixin that can be be included into the account model:

```rb
class Account < ApplicationRecord
  include Rodauth::Rails.model
end
```

It provides password attribute and validations (works for both password hash column and password hash table):

```rb
account = Account.new(email: "user@example.com", password: "foo")
account.password_hash #=> "$2a$12$k/Ub1I2iomi84Rac..."
account.valid? #=> false
account.errors[:password] #=> ["invalid password, does not meet requirements (minimum 6 characters)"]
```

And login validations:

```rb
account = Account.new(password: "secret", email: "foo")
account.valid? #=> false
account.errors[:email] #=> ["invalid login, not a valid email address"]
```

It also defines associations based on the Rodauth configuration:

```rb
account.remember_key #=> #<Account::RememberKey>
account.active_session_keys #=> [#<Account::ActiveSessionKey>, ...]
```

Alternative configurations are supported as well:

```rb
class Admin < ApplicationRecord
  include Rodauth::Rails.model(:admin)
end

Admin::RememberKey # can reference `admin_remember_keys`
```