### PR TITLE
Speed up rendering by limiting template formats

### DIFF
--- a/lib/rodauth/rails/feature/render.rb
+++ b/lib/rodauth/rails/feature/render.rb
@@ -35,6 +35,13 @@ module Rodauth
         rescue ActionView::MissingTemplate
           nil
         end
+
+        # Only look up template formats that the current request is accepting.
+        def _rails_controller_instance
+          controller = super
+          controller.formats = rails_request.formats.map(&:ref).compact
+          controller
+        end
       end
     end
   end


### PR DESCRIPTION
`ActionView::LookupContext` will by default look up templates in all known formats (33 of them). This results in quite a few system calls, which can slow down rendering, especially when filesystem access is slower (e.g. when using macOS with Docker).

Before processing an action, Action Controller reduces the list of formats only to formats that the current request accepts. However, rodauth-rails is rendering templates outside of action processing, so this code is not being executed. We fix this by calling it manually.

Fixes #48