### PR TITLE
Support internal_request feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,9 @@ end
 
 ### Rodauth instance
 
+_NOTE: You should probably be using the [internal_request] feature added to
+Rodauth 2.15 instead of this API._
+
 In some cases you might need to use Rodauth more programmatically, and perform
 Rodauth operations outside of the request context. rodauth-rails gives you a
 helper method for building a Rodauth instance:

--- a/lib/generators/rodauth/views_generator.rb
+++ b/lib/generators/rodauth/views_generator.rb
@@ -129,8 +129,9 @@ module Rodauth
         end
 
         def controller
-          rodauth = Rodauth::Rails.rodauth(configuration_name)
-          rodauth.rails_controller
+          rodauth = Rodauth::Rails.app.rodauth(configuration_name)
+          fail ArgumentError, "unknown rodauth configuration: #{configuration_name.inspect}" unless rodauth
+          rodauth.allocate.rails_controller
         end
 
         def configuration_name

--- a/lib/rodauth/rails.rb
+++ b/lib/rodauth/rails.rb
@@ -35,7 +35,7 @@ module Rodauth
         end
 
         if query || form
-          warn "The :query and :form keyword argumentas for Rodauth::Rails.rodauth have been deprecated. Please use the :params argument supported by internal_request feature instead."
+          warn "The :query and :form keyword arguments for Rodauth::Rails.rodauth have been deprecated. Please use the :params argument supported by internal_request feature instead."
           options[:params] = query || form
         end
 

--- a/lib/rodauth/rails.rb
+++ b/lib/rodauth/rails.rb
@@ -1,9 +1,6 @@
 require "rodauth/rails/version"
 require "rodauth/rails/railtie"
 
-require "rack/utils"
-require "stringio"
-
 module Rodauth
   module Rails
     class Error < StandardError

--- a/lib/rodauth/rails.rb
+++ b/lib/rodauth/rails.rb
@@ -30,12 +30,12 @@ module Rodauth
         LOCK.synchronize do
           unless auth_class.features.include?(:internal_request)
             auth_class.configure { enable :internal_request }
-            warn "Rodauth::Rails.rodauth requires the internal_request feature to be enabled. For now it was enabled automatically, but this behaviour will be removed in version 1.0.", uplevel: 1, category: :deprecated
+            warn "Rodauth::Rails.rodauth requires the internal_request feature to be enabled. For now it was enabled automatically, but this behaviour will be removed in version 1.0."
           end
         end
 
         if query || form
-          warn "The :query and :form keyword argumentas for Rodauth::Rails.rodauth have been deprecated. Please use the :params argument supported by internal_request feature instead.", uplevel: 1, category: :deprecated
+          warn "The :query and :form keyword argumentas for Rodauth::Rails.rodauth have been deprecated. Please use the :params argument supported by internal_request feature instead."
           options[:params] = query || form
         end
 

--- a/lib/rodauth/rails/feature.rb
+++ b/lib/rodauth/rails/feature.rb
@@ -10,6 +10,7 @@ module Rodauth
     require "rodauth/rails/feature/render"
     require "rodauth/rails/feature/email"
     require "rodauth/rails/feature/instrumentation"
+    require "rodauth/rails/feature/internal_request"
 
     include Rodauth::Rails::Feature::Base
     include Rodauth::Rails::Feature::Callbacks
@@ -17,5 +18,6 @@ module Rodauth
     include Rodauth::Rails::Feature::Render
     include Rodauth::Rails::Feature::Email
     include Rodauth::Rails::Feature::Instrumentation
+    include Rodauth::Rails::Feature::InternalRequest
   end
 end

--- a/lib/rodauth/rails/feature/callbacks.rb
+++ b/lib/rodauth/rails/feature/callbacks.rb
@@ -4,13 +4,17 @@ module Rodauth
       module Callbacks
         private
 
+        def _around_rodauth
+          rails_controller_around { super }
+        end
+
         # Runs controller callbacks and rescue handlers around Rodauth actions.
-        def _around_rodauth(&block)
+        def rails_controller_around
           result = nil
 
           rails_controller_rescue do
             rails_controller_callbacks do
-              result = catch(:halt) { super(&block) }
+              result = catch(:halt) { yield }
             end
           end
 

--- a/lib/rodauth/rails/feature/internal_request.rb
+++ b/lib/rodauth/rails/feature/internal_request.rb
@@ -1,0 +1,45 @@
+module Rodauth
+  module Rails
+    module Feature
+      module InternalRequest
+        def post_configure
+          super
+          return unless internal_request?
+
+          self.class.define_singleton_method(:internal_request) do |route, opts = {}|
+            url_options = ::Rails.application.config.action_mailer.default_url_options
+
+            scheme = url_options[:protocol]
+            port   = url_options[:port]
+            port ||= Rack::Request::DEFAULT_PORTS[scheme] if Rack.release < "2"
+            host   = url_options[:host]
+            host  += ":#{port}" if host && port
+
+            opts[:env] ||= {}
+            opts[:env]["HTTP_HOST"] ||= host if host
+            opts[:env]["rack.url_scheme"] ||= scheme if scheme
+
+            super(route, opts)
+          end
+        end
+
+        private
+
+        def rails_controller_around
+          return yield if internal_request?
+          super
+        end
+
+        def rails_instrument_request
+          return yield if internal_request?
+          super
+        end
+
+        def rails_instrument_redirection
+          return yield if internal_request?
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/rodauth/rails/feature/internal_request.rb
+++ b/lib/rodauth/rails/feature/internal_request.rb
@@ -6,7 +6,7 @@ module Rodauth
           super
           return unless internal_request?
 
-          self.class.define_singleton_method(:internal_request) do |route, opts = {}|
+          self.class.define_singleton_method(:internal_request) do |route, opts = {}, &blk|
             url_options = ::Rails.application.config.action_mailer.default_url_options
 
             scheme = url_options[:protocol]
@@ -19,7 +19,7 @@ module Rodauth
             opts[:env]["HTTP_HOST"] ||= host if host
             opts[:env]["rack.url_scheme"] ||= scheme if scheme
 
-            super(route, opts)
+            super(route, opts, &blk)
           end
         end
 

--- a/lib/rodauth/rails/feature/internal_request.rb
+++ b/lib/rodauth/rails/feature/internal_request.rb
@@ -7,7 +7,7 @@ module Rodauth
           return unless internal_request?
 
           self.class.define_singleton_method(:internal_request) do |route, opts = {}, &blk|
-            url_options = ::Rails.application.config.action_mailer.default_url_options
+            url_options = ::Rails.application.config.action_mailer.default_url_options || {}
 
             scheme = url_options[:protocol]
             port = url_options[:port]

--- a/lib/rodauth/rails/feature/internal_request.rb
+++ b/lib/rodauth/rails/feature/internal_request.rb
@@ -10,14 +10,19 @@ module Rodauth
             url_options = ::Rails.application.config.action_mailer.default_url_options
 
             scheme = url_options[:protocol]
-            port   = url_options[:port]
-            port ||= Rack::Request::DEFAULT_PORTS[scheme] if Rack.release < "2"
-            host   = url_options[:host]
-            host  += ":#{port}" if host && port
+            port = url_options[:port]
+            port||= Rack::Request::DEFAULT_PORTS[scheme] if Rack.release < "2"
+            host = url_options[:host]
+            host_with_port = host && port ? "#{host}:#{port}" : host
 
-            opts[:env] ||= {}
-            opts[:env]["HTTP_HOST"] ||= host if host
-            opts[:env]["rack.url_scheme"] ||= scheme if scheme
+            env = {
+              "HTTP_HOST" => host_with_port,
+              "rack.url_scheme" => scheme,
+              "SERVER_NAME" => host,
+              "SERVER_PORT" => port,
+            }.compact
+
+            opts = opts.merge(env: env) { |k, v1, v2| v2.merge(v1) }
 
             super(route, opts, &blk)
           end

--- a/lib/rodauth/rails/tasks.rake
+++ b/lib/rodauth/rails/tasks.rake
@@ -4,15 +4,15 @@ namespace :rodauth do
 
     puts "Routes handled by #{app}:"
 
-    app.opts[:rodauths].each_key do |rodauth_name|
-      rodauth = Rodauth::Rails.rodauth(rodauth_name)
+    app.opts[:rodauths].each do |configuration_name, auth_class|
+      auth_class.configure { enable :path_class_methods }
 
-      routes = rodauth.class.routes.map do |handle_method|
+      routes = auth_class.routes.map do |handle_method|
         path_method = "#{handle_method.to_s.sub(/\Ahandle_/, "")}_path"
 
         [
-          rodauth.public_send(path_method),
-          "rodauth#{rodauth_name && "(:#{rodauth_name})"}.#{path_method}",
+          auth_class.public_send(path_method),
+          "rodauth#{configuration_name && "(:#{configuration_name})"}.#{path_method}",
         ]
       end
 

--- a/rodauth-rails.gemspec
+++ b/rodauth-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "railties", ">= 4.2", "< 7"
-  spec.add_dependency "rodauth", "~> 2.11"
+  spec.add_dependency "rodauth", "~> 2.15"
   spec.add_dependency "sequel-activerecord_connection", "~> 1.1"
   spec.add_dependency "tilt"
   spec.add_dependency "bcrypt"

--- a/test/internal_request_test.rb
+++ b/test/internal_request_test.rb
@@ -20,6 +20,11 @@ class InternalRequestTest < UnitTest
     assert_match %r{http://foobar\.com}, email.body.to_s
   end
 
+  test "internal request eval" do
+    path = rodauth.internal_request_eval { login_path }
+    assert_equal "/login", path
+  end
+
   test "skipping callbacks" do
     env = { "QUERY_STRING" => "early_return=true" }
     rodauth.create_account(login: "user@example.com", password: "secret", env: env)

--- a/test/internal_request_test.rb
+++ b/test/internal_request_test.rb
@@ -1,47 +1,41 @@
 require "test_helper"
 
 class InternalRequestTest < UnitTest
-  def rodauth
-    klass = Class.new(RodauthApp.rodauth)
-    klass.configure { enable :internal_request }
-    klass
-  end
-
   test "inheriting URL options from config.action_mailer" do
-    rodauth.create_account(login: "user@example.com", password: "secret")
+    RodauthApp.rodauth.create_account(login: "user@example.com", password: "secret")
     email = ActionMailer::Base.deliveries.last
     assert_match %r{https://example\.com}, email.body.to_s
   end
 
   test "allowing overriding URL options" do
     env = { "HTTP_HOST" => "foobar.com", "rack.url_scheme" => "http" }
-    rodauth.create_account(login: "user@example.com", password: "secret", env: env)
+    RodauthApp.rodauth.create_account(login: "user@example.com", password: "secret", env: env)
     email = ActionMailer::Base.deliveries.last
     assert_match %r{http://foobar\.com}, email.body.to_s
   end
 
   test "internal request eval" do
-    path = rodauth.internal_request_eval { login_path }
+    path = RodauthApp.rodauth.internal_request_eval { login_path }
     assert_equal "/login", path
   end
 
   test "skipping callbacks" do
     env = { "QUERY_STRING" => "early_return=true" }
-    rodauth.create_account(login: "user@example.com", password: "secret", env: env)
+    RodauthApp.rodauth.create_account(login: "user@example.com", password: "secret", env: env)
     assert_equal 1, Account.count
   end
 
   test "skipping rescue handlers" do
     params = { "raise" => "true" }
     assert_raises NotImplementedError do
-      rodauth.create_account(login: "user@example.com", password: "secret", params: params)
+      RodauthApp.rodauth.create_account(login: "user@example.com", password: "secret", params: params)
     end
   end
 
   test "skipping instrumentation" do
     events = []
     ActiveSupport::Notifications.subscribe(/action_controller/) { |event| events << event }
-    rodauth.create_account(login: "user@example.com", password: "secret")
+    RodauthApp.rodauth.create_account(login: "user@example.com", password: "secret")
     assert_empty events
   end
 end

--- a/test/internal_request_test.rb
+++ b/test/internal_request_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class InternalRequestTest < UnitTest
+  def rodauth
+    klass = Class.new(RodauthApp.rodauth)
+    klass.configure { enable :internal_request }
+    klass
+  end
+
+  test "inheriting URL options from config.action_mailer" do
+    rodauth.create_account(login: "user@example.com", password: "secret")
+    email = ActionMailer::Base.deliveries.last
+    assert_match %r{https://example\.com}, email.body.to_s
+  end
+
+  test "allowing overriding URL options" do
+    env = { "HTTP_HOST" => "foobar.com", "rack.url_scheme" => "http" }
+    rodauth.create_account(login: "user@example.com", password: "secret", env: env)
+    email = ActionMailer::Base.deliveries.last
+    assert_match %r{http://foobar\.com}, email.body.to_s
+  end
+
+  test "skipping callbacks" do
+    env = { "QUERY_STRING" => "early_return=true" }
+    rodauth.create_account(login: "user@example.com", password: "secret", env: env)
+    assert_equal 1, Account.count
+  end
+
+  test "skipping rescue handlers" do
+    params = { "raise" => "true" }
+    assert_raises NotImplementedError do
+      rodauth.create_account(login: "user@example.com", password: "secret", params: params)
+    end
+  end
+
+  test "skipping instrumentation" do
+    events = []
+    ActiveSupport::Notifications.subscribe(/action_controller/) { |event| events << event }
+    rodauth.create_account(login: "user@example.com", password: "secret")
+    assert_empty events
+  end
+end

--- a/test/rails_app/app/lib/rodauth_app.rb
+++ b/test/rails_app/app/lib/rodauth_app.rb
@@ -4,7 +4,7 @@ class RodauthApp < Rodauth::Rails::App
       :login, :remember, :logout, :active_sessions,
       :reset_password, :change_password, :change_password_notify,
       :change_login, :verify_login_change,
-      :close_account, :lockout, :recovery_codes
+      :close_account, :lockout, :recovery_codes, :internal_request
 
     rails_controller { RodauthController }
 

--- a/test/rails_app/app/lib/rodauth_app.rb
+++ b/test/rails_app/app/lib/rodauth_app.rb
@@ -40,7 +40,7 @@ class RodauthApp < Rodauth::Rails::App
 
   configure(:json) do
     enable :jwt, :create_account, :verify_account
-    only_json? true
+    only_json? { !internal_request? }
     prefix "/json"
     jwt_secret "secret"
     account_status_column :status

--- a/test/rails_app/app/models/account.rb
+++ b/test/rails_app/app/models/account.rb
@@ -1,3 +1,4 @@
 class Account < ApplicationRecord
   validates_presence_of :email
+  include Rodauth::Rails.model
 end

--- a/test/rodauth_test.rb
+++ b/test/rodauth_test.rb
@@ -12,10 +12,10 @@ class RodauthTest < UnitTest
     rodauth = Rodauth::Rails.rodauth
     assert_nil rodauth.param_or_nil("foo")
 
-    rodauth = Rodauth::Rails.rodauth(query: { "foo" => { "bar" => "baz" } })
+    capture_io { rodauth = Rodauth::Rails.rodauth(query: { "foo" => { "bar" => "baz" } }) }
     assert_equal "baz", rodauth.raw_param("foo")["bar"]
 
-    rodauth = Rodauth::Rails.rodauth(form: { "foo" => { "bar" => "baz" } })
+    capture_io { rodauth = Rodauth::Rails.rodauth(form: { "foo" => { "bar" => "baz" } }) }
     assert_equal "baz", rodauth.raw_param("foo")["bar"]
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,7 @@ class UnitTest < ActiveSupport::TestCase
       ActiveRecord::Migrator.down(Rails.application.paths["db/migrate"].to_a)
     end
     ActiveRecord::Base.clear_cache! # clear schema cache
+    ActionMailer::Base.deliveries.clear
   end
 end
 
@@ -66,7 +67,6 @@ class IntegrationTest < UnitTest
 
   def teardown
     super
-    ActionMailer::Base.deliveries.clear
     Capybara.reset_sessions!
   end
 end


### PR DESCRIPTION
This adds support for the upcoming internal_request Rodauth feature. The following changes are made for internal requests:

* base URL defaults are picked up from `config.action_mailer.default_url_options`
* controller callbacks and rescue handlers are skipped during internal requests
* view rendering is skipped during internal requests
* controller instrumentation is skipped during internal requests

In the future we might deprecate the `Rodauth::Rails.rodauth` API for creating Rodauth instances in favour of the internal_request feature, but for now we just add a note to the README.

The tests also need to be added before merging.