### PR TITLE
Support `internal_request_eval`

### DIFF
--- a/lib/rodauth/rails/feature/internal_request.rb
+++ b/lib/rodauth/rails/feature/internal_request.rb
@@ -6,7 +6,7 @@ module Rodauth
           super
           return unless internal_request?
 
-          self.class.define_singleton_method(:internal_request) do |route, opts = {}|
+          self.class.define_singleton_method(:internal_request) do |route, opts = {}, &blk|
             url_options = ::Rails.application.config.action_mailer.default_url_options
 
             scheme = url_options[:protocol]
@@ -19,7 +19,7 @@ module Rodauth
             opts[:env]["HTTP_HOST"] ||= host if host
             opts[:env]["rack.url_scheme"] ||= scheme if scheme
 
-            super(route, opts)
+            super(route, opts, &blk)
           end
         end
 


### PR DESCRIPTION
Pass block to super in `internal_request` override, which is necessary to support [`internal_request_eval`](https://github.com/jeremyevans/rodauth/commit/6d482203af6e2bf662d094f1c8546793ab910738).