### PR TITLE
Add controller test integration

### DIFF
--- a/lib/rodauth/rails/railtie.rb
+++ b/lib/rodauth/rails/railtie.rb
@@ -23,8 +23,12 @@ module Rodauth
         # Rodauth uses RACK_ENV to set the default bcrypt hash cost
         ENV["RACK_ENV"] = "test" if ::Rails.env.test?
 
-        ActiveSupport.on_load(:action_controller_test_case) do
-          include Rodauth::Rails::Test::Controller
+        if ActionPack.version >= Gem::Version.new("5.0")
+          ActiveSupport.on_load(:action_controller_test_case) do
+            include Rodauth::Rails::Test::Controller
+          end
+        else
+          ActionController::TestCase.include Rodauth::Rails::Test::Controller
         end
       end
 

--- a/lib/rodauth/rails/railtie.rb
+++ b/lib/rodauth/rails/railtie.rb
@@ -1,5 +1,6 @@
 require "rodauth/rails/middleware"
 require "rodauth/rails/controller_methods"
+require "rodauth/rails/test"
 
 require "rails"
 
@@ -21,6 +22,10 @@ module Rodauth
       initializer "rodauth.test" do
         # Rodauth uses RACK_ENV to set the default bcrypt hash cost
         ENV["RACK_ENV"] = "test" if ::Rails.env.test?
+
+        ActiveSupport.on_load(:action_controller_test_case) do
+          include Rodauth::Rails::Test::Controller
+        end
       end
 
       rake_tasks do

--- a/lib/rodauth/rails/test.rb
+++ b/lib/rodauth/rails/test.rb
@@ -1,0 +1,7 @@
+module Rodauth
+  module Rails
+    module Test
+      autoload :Controller, "rodauth/rails/test/controller"
+    end
+  end
+end

--- a/lib/rodauth/rails/test/controller.rb
+++ b/lib/rodauth/rails/test/controller.rb
@@ -15,8 +15,6 @@ module Rodauth
         end
         ruby2_keywords(:process) if respond_to?(:ruby2_keywords, true)
 
-        delegate :rodauth, to: :@controller
-
         private
 
         def setup_rodauth

--- a/lib/rodauth/rails/test/controller.rb
+++ b/lib/rodauth/rails/test/controller.rb
@@ -1,0 +1,43 @@
+require "active_support/concern"
+
+module Rodauth
+  module Rails
+    module Test
+      module Controller
+        extend ActiveSupport::Concern
+
+        included do
+          setup :setup_rodauth
+        end
+
+        def process(*)
+          catch_rodauth { super }
+        end
+        ruby2_keywords(:process) if respond_to?(:ruby2_keywords, true)
+
+        delegate :rodauth, to: :@controller
+
+        private
+
+        def setup_rodauth
+          Rodauth::Rails.app.opts[:rodauths].each do |name, auth_class|
+            scope = auth_class.roda_class.new(request.env)
+            request.env[["rodauth", *name].join(".")] = auth_class.new(scope)
+          end
+        end
+
+        def catch_rodauth(&block)
+          result = catch(:halt, &block)
+
+          if result.is_a?(Array) # rodauth response
+            response.status = result[0]
+            response.headers.merge! result[1]
+            response.body = result[2]
+          end
+
+          response
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/test_controller_test.rb
+++ b/test/controllers/test_controller_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class TestControllerTest < ControllerTest
+  test "integration" do
+    get :auth2
+
+    assert_response 302
+    assert_redirected_to rodauth.login_url
+
+    account = Account.create!(email: "user@example.com", password: "secret", status: "verified")
+    login(account)
+
+    get :auth2
+
+    assert_response 200
+  end
+
+  private
+
+  def login(account)
+    rodauth.account_from_login(account.email)
+    rodauth.login_session("password")
+  end
+end

--- a/test/controllers/test_controller_test.rb
+++ b/test/controllers/test_controller_test.rb
@@ -5,7 +5,6 @@ class TestControllerTest < ActionController::TestCase
 
   test "integration" do
     get :auth2
-
     assert_response 302
     assert_redirected_to rodauth.login_url
 
@@ -13,7 +12,10 @@ class TestControllerTest < ActionController::TestCase
     login(account)
 
     get :auth2
+    assert_response 200
 
+    # session state is retained on further requests
+    get :auth2
     assert_response 200
   end
 

--- a/test/controllers/test_controller_test.rb
+++ b/test/controllers/test_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
-class TestControllerTest < ControllerTest
+class TestControllerTest < ActionController::TestCase
+  include TestSetupTeardown
+
   test "integration" do
     get :auth2
 

--- a/test/controllers/test_controller_test.rb
+++ b/test/controllers/test_controller_test.rb
@@ -9,7 +9,7 @@ class TestControllerTest < ActionController::TestCase
     assert_response 302
     assert_redirected_to rodauth.login_url
 
-    account = Account.create!(email: "user@example.com", password: "secret", status: "verified")
+    account = Account.create!(email: "user@example.com", password: "secret")
     login(account)
 
     get :auth2

--- a/test/controllers/test_controller_test.rb
+++ b/test/controllers/test_controller_test.rb
@@ -6,9 +6,10 @@ class TestControllerTest < ActionController::TestCase
   test "integration" do
     get :auth2
     assert_response 302
-    assert_redirected_to rodauth.login_url
+    assert_redirected_to "/login"
+    assert_equal "Please login to continue", flash[:alert]
 
-    account = Account.create!(email: "user@example.com", password: "secret")
+    account = Account.create!(email: "user@example.com", password: "secret", status: "verified")
     login(account)
 
     get :auth2
@@ -17,12 +18,22 @@ class TestControllerTest < ActionController::TestCase
     # session state is retained on further requests
     get :auth2
     assert_response 200
+
+    logout
+
+    get :auth2
+    assert_response 302
+    assert_equal "Please login to continue", flash[:alert]
   end
 
   private
 
   def login(account)
-    rodauth.account_from_login(account.email)
-    rodauth.login_session("password")
+    session[:account_id] = account.id
+    session[:authenticated_by] = ["password"]
+  end
+
+  def logout
+    session.clear
   end
 end

--- a/test/rails_app/app/models/account.rb
+++ b/test/rails_app/app/models/account.rb
@@ -1,4 +1,4 @@
 class Account < ApplicationRecord
-  include Rodauth::Rails.model
   validates_presence_of :email
+  include Rodauth::Rails.model
 end

--- a/test/rails_app/app/models/account.rb
+++ b/test/rails_app/app/models/account.rb
@@ -1,4 +1,5 @@
 class Account < ApplicationRecord
-  validates_presence_of :email
   include Rodauth::Rails.model
+  enum :status, unverified: 1, verified: 2, closed: 3
+  validates_presence_of :email
 end

--- a/test/rails_app/app/models/account.rb
+++ b/test/rails_app/app/models/account.rb
@@ -1,5 +1,4 @@
 class Account < ApplicationRecord
   include Rodauth::Rails.model
-  enum :status, unverified: 1, verified: 2, closed: 3
   validates_presence_of :email
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,10 +37,6 @@ class UnitTest < ActiveSupport::TestCase
   include TestSetupTeardown
 end
 
-class ControllerTest < ActionController::TestCase
-  include TestSetupTeardown
-end
-
 class IntegrationTest < UnitTest
   include Capybara::DSL
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -73,3 +73,20 @@ class IntegrationTest < UnitTest
     Capybara.reset_sessions!
   end
 end
+
+# a workaround to avoid MonitorMixin double-initialize error
+# https://github.com/rails/rails/issues/34790#issuecomment-681034561
+if RUBY_VERSION >= "2.6" && ActionPack.version < Gem::Version.new("5.0")
+  class ActionController::TestResponse < ActionDispatch::TestResponse
+    def recycle!
+      if RUBY_VERSION >= "2.7"
+        @mon_data = nil
+        @mon_data_owner_object_id = nil
+      else
+        @mon_mutex = nil
+        @mon_mutex_owner_object_id = nil
+      end
+      initialize
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -79,7 +79,7 @@ end
 if RUBY_VERSION >= "2.6" && ActionPack.version < Gem::Version.new("5.0")
   class ActionController::TestResponse < ActionDispatch::TestResponse
     def recycle!
-      if RUBY_VERSION >= "2.7"
+      if RUBY_VERSION >= "2.7" || RUBY_ENGINE == "jruby"
         @mon_data = nil
         @mon_data_owner_object_id = nil
       else

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,9 +10,7 @@ require "capybara/rails"
 ActiveRecord::Migrator.migrations_paths = [Rails.root.join("db/migrate")]
 Rails.backtrace_cleaner.remove_silencers! # show full stack traces
 
-class UnitTest < ActiveSupport::TestCase
-  self.test_order = :random
-
+module TestSetupTeardown
   def setup
     super
     if ActiveRecord.version >= Gem::Version.new("5.2")
@@ -32,6 +30,15 @@ class UnitTest < ActiveSupport::TestCase
     ActiveRecord::Base.clear_cache! # clear schema cache
     ActionMailer::Base.deliveries.clear
   end
+end
+
+class UnitTest < ActiveSupport::TestCase
+  self.test_order = :random
+  include TestSetupTeardown
+end
+
+class ControllerTest < ActionController::TestCase
+  include TestSetupTeardown
 end
 
 class IntegrationTest < UnitTest


### PR DESCRIPTION
This allows controllers calling Rodauth to be controller-tested, via `ActionController::TestCase` that's internally used by RSpec's controller specs. It ensures Rodauth instance(s) are set in request env, converts Rodauth responses into controller responses, and provides the `#rodauth` method.

```rb
# app/controllers/articles_controller.rb
class ArticlesController < ApplicationController
  before_action -> { rodauth.require_authentication }

  def index
    @articles = current_account.articles.all
  end

  # ...
end
```
```rb
# test/controllers/articles_controller_test.rb
class ArticlesControllerTest < ActionController::TestCase
  test "authentication" do
    get :index

    assert_response 302
    assert_redirected_to rodauth.login_path

    account = Account.create(email: "user@example.com", password: "secret", status: "verified")
    login(account)

    get :index

    assert_response 200
  end

  private

  def login(account)
    rodauth.account_from_login(account.email)
    rodauth.login_session("password")
  end
end
```

Afterwards I would consider the possibility of adding some login/logout test helper methods, similar to what Devise has.
