### PR TITLE
Optionally pass config name to RodauthMailer methods so @email_link includes the config prefix

### DIFF
--- a/lib/generators/rodauth/templates/app/mailers/rodauth_mailer.rb
+++ b/lib/generators/rodauth/templates/app/mailers/rodauth_mailer.rb
@@ -1,54 +1,54 @@
 class RodauthMailer < ApplicationMailer
-  def verify_account(account_id, key)
-    @email_link = rodauth.verify_account_url(key: email_token(account_id, key))
+  def verify_account(account_id, key, name = nil)
+    @email_link = rodauth(name).verify_account_url(key: email_token(account_id, key, name))
     @account = Account.find(account_id)
 
-    mail to: @account.email, subject: rodauth.verify_account_email_subject
+    mail to: @account.email, subject: rodauth(name).verify_account_email_subject
   end
 
-  def reset_password(account_id, key)
-    @email_link = rodauth.reset_password_url(key: email_token(account_id, key))
+  def reset_password(account_id, key, name = nil)
+    @email_link = rodauth(name).reset_password_url(key: email_token(account_id, key, name))
     @account = Account.find(account_id)
 
-    mail to: @account.email, subject: rodauth.reset_password_email_subject
+    mail to: @account.email, subject: rodauth(name).reset_password_email_subject
   end
 
-  def verify_login_change(account_id, old_login, new_login, key)
+  def verify_login_change(account_id, old_login, new_login, key, name = nil)
     @old_login  = old_login
     @new_login  = new_login
-    @email_link = rodauth.verify_login_change_url(key: email_token(account_id, key))
+    @email_link = rodauth(name).verify_login_change_url(key: email_token(account_id, key, name))
     @account = Account.find(account_id)
 
-    mail to: new_login, subject: rodauth.verify_login_change_email_subject
+    mail to: new_login, subject: rodauth(name).verify_login_change_email_subject
   end
 
-  def password_changed(account_id)
+  def password_changed(account_id, name = nil)
     @account = Account.find(account_id)
 
-    mail to: @account.email, subject: rodauth.password_changed_email_subject
+    mail to: @account.email, subject: rodauth(name).password_changed_email_subject
   end
 
-  # def email_auth(account_id, key)
-  #   @email_link = rodauth.email_auth_url(key: email_token(account_id, key))
+  # def email_auth(account_id, key, name = nil)
+  #   @email_link = rodauth(name).email_auth_url(key: email_token(account_id, key, name))
   #   @account = Account.find(account_id)
 
-  #   mail to: @account.email, subject: rodauth.email_auth_email_subject
+  #   mail to: @account.email, subject: rodauth(name).email_auth_email_subject
   # end
 
-  # def unlock_account(account_id, key)
-  #   @email_link = rodauth.unlock_account_url(key: email_token(account_id, key))
+  # def unlock_account(account_id, key, name = nil)
+  #   @email_link = rodauth(name).unlock_account_url(key: email_token(account_id, key, name))
   #   @account = Account.find(account_id)
 
-  #   mail to: @account.email, subject: rodauth.unlock_account_email_subject
+  #   mail to: @account.email, subject: rodauth(name).unlock_account_email_subject
   # end
 
   private
 
-  def email_token(account_id, key)
-    "#{account_id}_#{rodauth.compute_hmac(key)}"
+  def email_token(account_id, key, name)
+    "#{account_id}_#{rodauth(name).compute_hmac(key)}"
   end
 
-  def rodauth(name = nil)
+  def rodauth(name)
     RodauthApp.rodauth(name).allocate
   end
 end


### PR DESCRIPTION
I created an `admin` account configuration like this:

```
class RodauthAdmin < RodauthBase # inherit common settings
  configure do
    # List of authentication features that are loaded.
    prefix "/admin"
  end
```

And the verification email link that was generated upon account creation didn't include `/admin` in the path.

Currently, there doesn't seem to be a way to pass in configuration names (like `:admin`) to methods in `RodauthMailer` that can be used to call `#RodauthApp.rodauth` so the correct path for the configuration is generated.

I quickly made the following changes to the `app/mailers/rodauth_mailer.rb`. There might be a better way to do this.

I'm posting this as a draft for your consideration. I'm happy to help contribute to this project in any way I can.