### PR TITLE
Don't use enable_extension under Sequel, which doesn't support it

### DIFF
--- a/lib/generators/rodauth/migration/sequel/base.erb
+++ b/lib/generators/rodauth/migration/sequel/base.erb
@@ -1,5 +1,5 @@
 <% if db.database_type == :postgres -%>
-enable_extension "citext"
+run "CREATE EXTENSION IF NOT EXISTS citext"
 
 <% end -%>
 create_table :accounts do


### PR DESCRIPTION
As noted here:
> It's trivial to use run "CREATE EXTENSION citext" in your migration if you want to add the extension.
https://github.com/jeremyevans/sequel/pull/819#issuecomment-43821533

Note enable_extension uses "IF NOT EXISTS", as per:
https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/PostgreSQLAdapter.html#method-i-enable_extension