### PR TITLE
Support newrelic_rpm gem instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* Support `newrelic_rpm` gem instrumentation (@janko)
+
 ## 1.5.1 (2022-06-19)
 
 * Fix syntax for creating `citext` PG extension in Sequel base migration (@Empact)

--- a/lib/rodauth/rails/app.rb
+++ b/lib/rodauth/rails/app.rb
@@ -59,6 +59,12 @@ module Rodauth
         rodauth(name) or fail ArgumentError, "unknown rodauth configuration: #{name.inspect}"
       end
 
+      # The newrelic_rpm gem expects this when we pass the roda class as
+      # :controller in instrumentation payload.
+      def self.controller_path
+        name.underscore
+      end
+
       module RequestMethods
         def rodauth(name = nil)
           prefix = scope.rodauth(name).prefix

--- a/lib/rodauth/rails/feature/instrumentation.rb
+++ b/lib/rodauth/rails/feature/instrumentation.rb
@@ -32,7 +32,7 @@ module Rodauth
           request = rails_request
 
           raw_payload = {
-            controller: scope.class.superclass.name,
+            controller: self.class.roda_class.name,
             action: "call",
             request: request,
             params: request.filtered_parameters,


### PR DESCRIPTION
The newrelic_rpm gem expects `:controller` in instrumentation event payload to point to an actual Rails controller, so it tries calling `controller_path` on it. I considered putting the Rodauth controller there, but I found it misleading, since it's the Rodauth application processing the request, the Rodauth controller is only doing view rendering. In the end I decided to just define a `controller_path` method on the Rodauth app.

Closes #119
