### PR TITLE
Add: fixtures

### DIFF
--- a/lib/generators/rodauth/install_generator.rb
+++ b/lib/generators/rodauth/install_generator.rb
@@ -70,8 +70,11 @@ module Rodauth
           end
         end
 
-        def create_fixtures
-          template "app/test/fixtures/accounts.yml"                
+        def create_fixtures    
+          # We should be able to access the rails app, and check the config object.          
+          # if Rails.application.config.generators.options[:test_unit][:fixture]
+            template "app/test/fixtures/accounts.yml"                
+          # end
         end
 
         def show_instructions

--- a/lib/generators/rodauth/install_generator.rb
+++ b/lib/generators/rodauth/install_generator.rb
@@ -70,6 +70,10 @@ module Rodauth
           end
         end
 
+        def create_fixtures
+          template "app/test/fixtures/accounts.yml"                
+        end
+
         def show_instructions
           readme "INSTRUCTIONS" if behavior == :invoke
         end

--- a/lib/generators/rodauth/install_generator.rb
+++ b/lib/generators/rodauth/install_generator.rb
@@ -71,10 +71,10 @@ module Rodauth
         end
 
         def create_fixtures    
-          # We should be able to access the rails app, and check the config object.          
-          # if Rails.application.config.generators.options[:test_unit][:fixture]
+          # We should be able to access the rails app, and check the config object.   
+          if ::Rails.application.config.generators.options[:test_unit][:fixture]
             template "app/test/fixtures/accounts.yml"                
-          # end
+          end
         end
 
         def show_instructions

--- a/lib/generators/rodauth/templates/app/test/fixtures/accounts.yml
+++ b/lib/generators/rodauth/templates/app/test/fixtures/accounts.yml
@@ -1,0 +1,32 @@
+---
+# For both users: password is "password" for both accounts
+# This allows you do run request specs, or ActionDispatch::IntegrationTest
+# Here is an example:
+##### test_helper.rb
+#
+# class ActionDispatch::IntegrationTest
+#
+#  def login(account)
+#     #  you can login like this:
+#     # session[:account_id] = account.id
+#     # session[:authenticated_by] = ["password"] # or ["password", "totp"] for MFA
+#     # post login_path
+#     # or like this: 
+#     post "/login", params: {"login"=>"brian@queen.com", "password"=>"password"}
+#   end
+#
+#   def logout
+#     session.clear
+#     follow_redirect!
+#   end  
+# end
+
+one:
+  email: freddie@queen.com
+  password_hash: <%= BCrypt::Password.create("password", cost: BCrypt::Engine::MIN_COST).to_s %>
+  status: 2
+
+two:
+  email: brian@queen.com
+  password_hash: <%= BCrypt::Password.create("password", cost: BCrypt::Engine::MIN_COST).to_s %>
+  status: 2

--- a/lib/generators/rodauth/templates/app/test/fixtures/accounts.yml
+++ b/lib/generators/rodauth/templates/app/test/fixtures/accounts.yml
@@ -1,26 +1,4 @@
 ---
-# For both users: password is "password" for both accounts
-# This allows you do run request specs, or ActionDispatch::IntegrationTest
-# Here is an example:
-##### test_helper.rb
-#
-# class ActionDispatch::IntegrationTest
-#
-#  def login(account)
-#     #  you can login like this:
-#     # session[:account_id] = account.id
-#     # session[:authenticated_by] = ["password"] # or ["password", "totp"] for MFA
-#     # post login_path
-#     # or like this: 
-#     post "/login", params: {"login"=>"brian@queen.com", "password"=>"password"}
-#   end
-#
-#   def logout
-#     session.clear
-#     follow_redirect!
-#   end  
-# end
-
 one:
   email: freddie@queen.com
   password_hash: <%= BCrypt::Password.create("password", cost: BCrypt::Engine::MIN_COST).to_s %>

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -100,4 +100,10 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       assert_file "app/views/rodauth_mailer/#{template}.text.erb"
     end
   end
+
+  test "fixture" do
+    run_generator
+
+    assert_file "app/test/fixtures/accounts.yml"
+  end
 end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -106,4 +106,9 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/test/fixtures/accounts.yml"
   end
+
+  test "fixtures - skip if configuration rejects fixtures" do
+    ::Rails.application.config.generators.options[:test_unit][:fixture] = false
+    refute_file "app/test/fixtures/accounts.yml"    
+  end
 end


### PR DESCRIPTION
### What is this?

* PR for adding fixtures.
* Assumes folks will be using an `Account` name. This is hard coded.
* Fixtures placed in `test/fixtures` location as per convention.
* I made assumptions about how the hash will be created. It may be incorrect.

### Why?

I want to automatically create user accounts as fixtures, so I can run request specs without creating accounts on the fly:

```rb
# don't want to do this
account = Account.create(email: ....etc) #
login(account)

# I want this:
account  = accounts(:one) # fixtures
login(account) # preferably using the same login params used by rodauth

def login(account)
    post "/login", params: {"login"=>"brian@queen.com", "password"=>"password"}
end
```

(By the way, is there any way of getting a hold of a rodauth object in tests so we can write?
```rb
   post rodauth.login_path # etc.
```

I hope this is useful/helpful. if not feel free to discard.