### PR TITLE
fix: bug - rails_account should return nil when logged_in? == false

### DIFF
--- a/lib/rodauth/rails/feature/base.rb
+++ b/lib/rodauth/rails/feature/base.rb
@@ -9,6 +9,8 @@ module Rodauth
         end
 
         def rails_account
+          return unless logged_in?
+
           account_from_session unless account
 
           unless account

--- a/test/integration/base_test.rb
+++ b/test/integration/base_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+require "sequel/model"
+
+class BaseTest < IntegrationTest
+  test "rails_account.nil? if no one logged in" do
+    assert_nil Rodauth::Rails.rodauth.rails_account
+  end
+
+  test "build authenticated session" do
+    account = Account.create!(email: "user@example.com", password: "password")
+
+    rodauth = Rodauth::Rails.rodauth
+    rodauth.scope.env["rodauth"] = rodauth
+
+    error = assert_raises(Rodauth::InternalRequestError) { Rodauth::Rails.authenticated.call(rodauth.request) }
+    assert_equal :login_required, error.reason
+
+    rodauth.account_from_login("user@example.com")
+    rodauth.login_session("password")
+    assert_equal account, rodauth.rails_account
+    # assert_equal true, Rodauth::Rails.authenticated.call(rodauth.request)    
+  end
+end

--- a/test/integration/base_test.rb
+++ b/test/integration/base_test.rb
@@ -18,7 +18,6 @@ class BaseTest < IntegrationTest
 
     rodauth.account_from_login("user@example.com")
     rodauth.login_session("password")
-    assert_equal account, rodauth.rails_account
-    # assert_equal true, Rodauth::Rails.authenticated.call(rodauth.request)    
+    assert_equal account, rodauth.rails_account    
   end
 end


### PR DESCRIPTION
Fix for [rails_account not returning nil](https://github.com/janko/rodauth-rails/discussions/138)

Not sure if this is the implementation desired, or whether I am testing adequately: pls do not hesitate to send back any changes required.

