### PR TITLE
Verify account grace period generator fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ gemfiles/*.lock
 pkg/
 database.sqlite3
 tmp/
+.ruby-version

--- a/lib/generators/rodauth/templates/app/misc/rodauth_main.rb
+++ b/lib/generators/rodauth/templates/app/misc/rodauth_main.rb
@@ -155,7 +155,7 @@ class RodauthMain < Rodauth::Rails::Auth
 
     # ==> Deadlines
     # Change default deadlines for some actions.
-    # verify_account_grace_period 3.days
+    # verify_account_grace_period 3.days.to_i
     # reset_password_deadline_interval Hash[hours: 6]
     # verify_login_change_deadline_interval Hash[days: 2]
 <% unless jwt? -%>


### PR DESCRIPTION
Providing `verify_account_grace_period` as `ActiveSupport::Duration` does not work with` jwt` feature enabled.

During JWT encode/decode process it will be converted to string

```ruby
token = JWT.encode({ unverified_account: 3.days }, Rails.application.secret_key_base)
JWT.decode(token, Rails.application.secret_key_base)
# => [{"unverified_account"=>"259200"}, {"alg"=>"HS256"}]

token = JWT.encode({ unverified_account: 3.days.to_i }, Rails.application.secret_key_base)
JWT.decode(token, Rails.application.secret_key_base)
# => [{"unverified_account"=>259200}, {"alg"=>"HS256"}]
```

while [Rodauth expects integer](https://github.com/jeremyevans/rodauth/blob/859de3a9e3a74a1449a881f7d269516ff8c25831/lib/rodauth/features/verify_account_grace_period.rb#L90).

I was thinking about adding this to generator only if `jwt` feature is enabled but I think it could lead to unexpected situations if jwt is enabled after grace period is already set with `ActiveSupport::Duration`.

I've also added `.ruby-version` to `.gitignore` to make it easier for contributors to select ruby version in development. Hope that is ok?