### PR TITLE
Added confirm_password feature to views generator

### DIFF
--- a/lib/generators/rodauth/views_generator.rb
+++ b/lib/generators/rodauth/views_generator.rb
@@ -41,6 +41,7 @@ module Rodauth
           recovery_codes:      %w[recovery_codes add_recovery_codes recovery_auth],
           webauthn:            %w[webauthn_setup webauthn_auth webauthn_remove],
           webauthn_autofill:   %w[webauthn_autofill],
+          confirm_password:    %w[confirm_password],
         }
 
         def create_views

--- a/test/generators/views_generator_test.rb
+++ b/test/generators/views_generator_test.rb
@@ -24,10 +24,11 @@ class ViewsGeneratorTest < Rails::Generators::TestCase
   end
 
   test "choosing features" do
-    run_generator %w[lockout]
+    run_generator %w[lockout confirm_password]
 
     assert_file "app/views/rodauth/unlock_account_request.html.erb"
     assert_file "app/views/rodauth/unlock_account.html.erb"
+    assert_file "app/views/rodauth/confirm_password.html.erb"
 
     assert_no_file "app/views/rodauth/login.html.erb"
     assert_no_file "app/views/rodauth/create_account.html.erb"


### PR DESCRIPTION
PR adds an ability to generate Rails view for Confirm Password feature (https://rodauth.jeremyevans.net/rdoc/files/doc/confirm_password_rdoc.html). 