### PR TITLE
Update OIDC guideline's link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Provides Rails integration for the [Rodauth] authentication framework.
 * [Rodauth: A Refreshing Authentication Solution for Ruby](https://janko.io/rodauth-a-refreshing-authentication-solution-for-ruby/)
 * [Rails Authentication with Rodauth](https://janko.io/adding-authentication-in-rails-with-rodauth/)
 * [Multifactor Authentication in Rails with Rodauth](https://janko.io/adding-multifactor-authentication-in-rails-with-rodauth/)
-* [How to build an OIDC provider using rodauth-oauth on Rails](https://honeyryderchuck.gitlab.io/httpx/2021/03/15/oidc-provider-on-rails-using-rodauth-oauth.html)
+* [How to build an OIDC provider using rodauth-oauth on Rails](https://honeyryderchuck.gitlab.io/2021/03/15/oidc-provider-on-rails-using-rodauth-oauth.html)
 * [What It Took to Build a Rails Integration for Rodauth](https://janko.io/what-it-took-to-build-a-rails-integration-for-rodauth/)
 * [Social Login in Rails with Rodauth](https://janko.io/social-login-in-rails-with-rodauth/)
 * [Passkey Authentication with Rodauth](https://janko.io/passkey-authentication-with-rodauth/)
@@ -282,7 +282,7 @@ class RodauthMain < Rodauth::Rails::Auth
     after_login { rails_cookies.permanent[:last_account_id] = account_id }
   end
 end
-``` 
+```
 
 ## Views
 
@@ -593,7 +593,7 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     post "/logout"
     assert_redirected_to "/"
   end
-  
+
   test "required authentication" do
     get :index
 
@@ -617,7 +617,7 @@ end
 ```
 
 For more examples and information about testing with rodauth, see
-[this wiki page about testing](https://github.com/janko/rodauth-rails/wiki/Testing). 
+[this wiki page about testing](https://github.com/janko/rodauth-rails/wiki/Testing).
 
 ## Configuring
 


### PR DESCRIPTION
I found the link to `How to build an OIDC provider using rodauth-oauth on Rails` was no longer valid, so I made a slight update on it.