### PR TITLE
Use `attributes_before_type_cast` in `Rodauth::Rails.rodauth` (#292)

### DIFF
--- a/lib/rodauth/rails.rb
+++ b/lib/rodauth/rails.rb
@@ -39,7 +39,7 @@ module Rodauth
 
         instance = auth_class.internal_request_eval(options) do
           if defined?(ActiveRecord::Base) && account.is_a?(ActiveRecord::Base)
-            @account = account.attributes.symbolize_keys
+            @account = account.attributes_before_type_cast.symbolize_keys
           elsif defined?(Sequel::Model) && account.is_a?(Sequel::Model)
             @account = account.values
           end

--- a/test/rodauth_test.rb
+++ b/test/rodauth_test.rb
@@ -15,6 +15,7 @@ class RodauthTest < UnitTest
     rodauth = Rodauth::Rails.rodauth(account: account)
     assert_equal "user@example.com", rodauth.send(:email_to)
     assert_equal account.id, rodauth.session_value
+    assert_equal account.status_before_type_cast, rodauth.account[:status]
   end
 
   test "allows setting Sequel account" do


### PR DESCRIPTION
Do not type cast ActiveRecord model instance attributes in instance returned from `Rodauth::Rails.rodauth`. Fixes problems with integer `status` column values being typecasted to string values by enum definition in `Account` model.