### PR TITLE
remove redudant index name: audit_at_idx

### DIFF
--- a/lib/generators/rodauth/migration/active_record/audit_logging.erb
+++ b/lib/generators/rodauth/migration/active_record/audit_logging.erb
@@ -12,5 +12,5 @@ create_table :<%= table_prefix %>_authentication_audit_logs<%= primary_key_type 
   t.string :metadata
 <% end -%>
   t.index [:<%= table_prefix %>_id, :at], name: "audit_<%= table_prefix %>_at_idx"
-  t.index :at, name: "audit_at_idx"
+  t.index :at
 end

--- a/lib/generators/rodauth/migration/sequel/audit_logging.erb
+++ b/lib/generators/rodauth/migration/sequel/audit_logging.erb
@@ -13,5 +13,5 @@ create_table :<%= table_prefix %>_authentication_audit_logs do
   String :metadata
 <% end -%>
   index [:<%= table_prefix %>_id, :at], name: :audit_<%= table_prefix %>_at_idx
-  index :at, name: :audit_at_idx
+  index :at
 end


### PR DESCRIPTION
This PR resolves https://github.com/janko/rodauth-rails/issues/305

The hardcoded id name is causing conflicts when used with multiple accounts.
Since rodauth does not rely on this index name, we are removing it completely and relying the default generated by rails.

Migrated table sample

<img width="631" alt="image" src="https://github.com/janko/rodauth-rails/assets/923493/49790545-9c56-4171-aaca-ec7e79ab5a92">
