### PR TITLE
Add support for Rails 8.0

### DIFF
--- a/gemfiles/Gemfile.rails-8.0
+++ b/gemfiles/Gemfile.rails-8.0
@@ -5,7 +5,7 @@ gemspec path: ".."
 gem "rake", "~> 12.0"
 gem "warning"
 
-gem "rails", "~> 8.0.0.rc1"
+gem "rails", "~> 8.0.0"
 gem "sqlite3", "~> 2.0",                platforms: :mri
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 

--- a/rodauth-rails.gemspec
+++ b/rodauth-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["README.md", "LICENSE.txt", "lib/**/*", "*.gemspec"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 5.0", "< 8"
+  spec.add_dependency "railties", ">= 5.0", "< 8.1"
   spec.add_dependency "rodauth", "~> 2.36"
   spec.add_dependency "roda", "~> 3.76"
   spec.add_dependency "sequel-activerecord_connection", "~> 1.1"


### PR DESCRIPTION
# Overview

This PR adds support for Rails 8.0 which has been officially released: https://rubyonrails.org/2024/11/7/rails-8-no-paas-required.

## Notes

* Update `Gemfile.rails-8.0`
* Update `rodauth-rails.gemspec`

Note: This PR depends on https://github.com/janko/sequel-activerecord_connection/pull/33

Thank you for all of your great work on this gem!