### PR TITLE
Bump actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       RAILS_VERSION: ${{ matrix.rails }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
actions/checkout@v4 uses Node.js 20, which reached EOL in Spring 2026.
v6 runs on Node.js 24 and improves credential security.

FYI: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/