### PR TITLE
Filter Rodauth tokens from Rails logs

### DIFF
--- a/lib/rodauth/rails/railtie.rb
+++ b/lib/rodauth/rails/railtie.rb
@@ -7,6 +7,10 @@ require "rails"
 module Rodauth
   module Rails
     class Railtie < ::Rails::Railtie
+      initializer "rodauth.filter_parameters" do |app|
+        app.config.filter_parameters << /\Akey\z/
+      end
+
       initializer "rodauth.middleware", after: :load_config_initializers do |app|
         if Rodauth::Rails.middleware?
           app.middleware.use Rodauth::Rails::Middleware

--- a/test/integration/parameter_filtering_test.rb
+++ b/test/integration/parameter_filtering_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class ParameterFilteringTest < ActionDispatch::IntegrationTest
+  include TestSetupTeardown
+
+  test "filters the rodauth token parameter from request logs" do
+    get "/reset-password", params: {
+      key: "secret",
+      keyboard: "dvorak",
+    }
+
+    assert_equal "[FILTERED]", request.filtered_parameters["key"]
+    assert_includes request.filtered_path, "key=[FILTERED]"
+    assert_equal "dvorak", request.filtered_parameters["keyboard"]
+  end
+end


### PR DESCRIPTION
Rodauth email links use a bare `key` query parameter for reset, verification, and authentication tokens. Rails' default `:_key` filter doesn't match it, so those tokens can show up in both the request path and parameters in Rails logs.

This PR adds an exact `/\Akey\z/` filter in the Railtie. The anchored regexp keeps unrelated parameters like `keyboard` visible, and placing it in the Railtie means existing apps are protected when they upgrade too.

I added an integration test covering `filtered_parameters`, `filtered_path`, and the similarly named parameter case.